### PR TITLE
chore(frontend): disallow future dates in datepicker

### DIFF
--- a/redi-connect-front/src/components/LogMentoringSessionDialog.tsx
+++ b/redi-connect-front/src/components/LogMentoringSessionDialog.tsx
@@ -195,9 +195,7 @@ const Form = withStyles(styles)(
     return (
       <MuiPickersUtilsProvider utils={MomentUtils}>
         {submitResult === "error" && (
-          <Paper
-            className={clsx(classes.submitError, classes.submitResult)}
-          >
+          <Paper className={clsx(classes.submitError, classes.submitResult)}>
             An error occurred, please try again.
           </Paper>
         )}
@@ -216,6 +214,7 @@ const Form = withStyles(styles)(
               onChange={changeDate}
               fullWidth
               disabled={isSubmitting}
+              maxDate={new Date()}
             />
             <FormControl className={classes.margin} fullWidth>
               <InputLabel


### PR DESCRIPTION
Simple enough fix, just needed a maxDate prop passed to the datepicker component.

Prevents user from inputting a date in the future to the datepicker in log mentoring session dialog.