### PR TITLE
feat(all): add github profile url to mentor/mentee contact information

### DIFF
--- a/redi-connect-admin/src/App.js
+++ b/redi-connect-admin/src/App.js
@@ -253,6 +253,7 @@ const RedProfileShow = props => (
           <TextField source="expectations" />
           <TextField source="contactEmail" />
           <TextField source="linkedInProfileUrl" />
+          <TextField source="githubProfileUrl" />
           <TextField source="slackUsername" />
           <TextField source="telephoneNumber" />
 
@@ -415,6 +416,7 @@ const RedProfileEdit = props => (
         <TextInput source="expectations" multiline />
         <TextInput source="contactEmail" />
         <TextInput source="linkedInProfileUrl" />
+        <TextInput source="githubProfileUrl" />
         <TextInput source="slackUsername" />
         <TextInput source="telephoneNumber" />
         <SelectArrayInput

--- a/redi-connect-backend/common/models/red-profile.json
+++ b/redi-connect-backend/common/models/red-profile.json
@@ -76,6 +76,9 @@
     "slackUsername": {
       "type": "string"
     },
+    "githubProfileUrl": {
+      "type": "string"
+    },
     "telephoneNumber": {
       "type": "string"
     },

--- a/redi-connect-backend/scripts/seed-database.js
+++ b/redi-connect-backend/scripts/seed-database.js
@@ -119,7 +119,7 @@ const users = fp.compose(
         mentor_workPlace: randomString(),
         mentee_occupationCategoryId:
           menteeOccupationCategoriesIds[
-            Math.floor(Math.random() * menteeOccupationCategoriesIds.length)
+          Math.floor(Math.random() * menteeOccupationCategoriesIds.length)
           ],
         mentee_occupationJob_placeOfEmployment: randomString(),
         mentee_occupationJob_position: randomString(),
@@ -136,6 +136,7 @@ const users = fp.compose(
         personalDescription: randomString(undefined, 300),
         contactEmail: email,
         slackUsername: randomString(),
+        githubProfileUrl: randomString(),
         telephoneNumber: randomString(),
         categories: categories.map(c => c.id).filter(() => Math.random() < 0.2),
         menteeCountCapacity: Math.floor(Math.random() * 4),
@@ -198,6 +199,7 @@ const ericMenteeRedProfile = {
     'eric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.com',
   contactEmail: 'eric@binarylights.com',
   slackUsername: '',
+  githubProfileUrl: '',
   telephoneNumber: '',
   categories: [
     'blockchain',
@@ -241,6 +243,7 @@ const ericMentorRedProfile = {
     'eric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.com',
   contactEmail: 'info@binarylights.com',
   slackUsername: '',
+  githubProfileUrl: '',
   telephoneNumber: '',
   categories: [
     'blockchain',
@@ -282,6 +285,7 @@ const isabelleMentorRedProfile = {
     'eric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.com',
   contactEmail: 'isabelle@redi-school.org',
   slackUsername: '',
+  githubProfileUrl: '',
   telephoneNumber: '',
   categories: [
     'blockchain',
@@ -323,6 +327,7 @@ const ericAdminRedProfile = {
     'eric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.comeric@binarylights.com',
   contactEmail: 'cloud-accounts@redi-school.org',
   slackUsername: '',
+  githubProfileUrl: '',
   telephoneNumber: '',
   categories: [
     'blockchain',

--- a/redi-connect-front/src/components/ContactInfo.tsx
+++ b/redi-connect-front/src/components/ContactInfo.tsx
@@ -5,7 +5,8 @@ import { Grid, Icon } from "@material-ui/core";
 import EmailIcon from "@material-ui/icons/Email";
 import PhoneIcon from "@material-ui/icons/Phone";
 
-const SlackIcon = <Icon className={clsx("fab fa-slack")} />;
+const slackIcon = <Icon className={clsx("fab fa-slack")} />;
+const githubIcon = <Icon className={clsx("fab fa-github")} />;
 
 export const ContactInfo = ({ profile }: { profile: RedProfile }) => (
   <>
@@ -14,10 +15,13 @@ export const ContactInfo = ({ profile }: { profile: RedProfile }) => (
       <Placeholder icon={<EmailIcon />} content={profile.contactEmail} />
     )}
     {profile.slackUsername && (
-      <Placeholder icon={SlackIcon} content={profile.slackUsername} />
+      <Placeholder icon={slackIcon} content={profile.slackUsername} />
     )}
     {profile.telephoneNumber && (
       <Placeholder icon={<PhoneIcon />} content={profile.telephoneNumber} />
+    )}
+    {profile.githubProfileUrl && (
+      <Placeholder icon={githubIcon} content={profile.githubProfileUrl} />
     )}
   </>
 );

--- a/redi-connect-front/src/pages/app/me/Me.tsx
+++ b/redi-connect-front/src/pages/app/me/Me.tsx
@@ -74,6 +74,7 @@ export interface SignUpFormValues {
   personalDescription: string;
   contactEmail: string;
   linkedInProfileUrl: string;
+  githubProfileUrl: string;
   slackUsername: string;
   telephoneNumber: string;
   categories: string[];
@@ -161,6 +162,10 @@ const validationSchema = Yup.object({
     .max(255)
     .url()
     .label("LinkedIn Profile"),
+  githubProfileUrl: Yup.string()
+    .max(255)
+    .url()
+    .label("Github Profile"),
   slackUsername: Yup.string()
     .max(255)
     .label("Slack username"),

--- a/redi-connect-front/src/pages/app/me/steps/Step4ContactData.tsx
+++ b/redi-connect-front/src/pages/app/me/steps/Step4ContactData.tsx
@@ -14,6 +14,7 @@ export const Step4ContactData = (
     values: {
       contactEmail,
       linkedInProfileUrl,
+      githubProfileUrl,
       slackUsername,
       telephoneNumber
     },
@@ -106,6 +107,25 @@ export const Step4ContactData = (
           startAdornment: (
             <InputAdornment position="start">
               <PhoneIcon />
+            </InputAdornment>
+          )
+        }}
+      />
+       <TextField
+        id="githubProfileUrl"
+        name="githubProfileUrl"
+        helperText={touched.githubProfileUrl ? errors.githubProfileUrl : ""}
+        error={touched.githubProfileUrl && Boolean(errors.githubProfileUrl)}
+        label="Github Profile"
+        value={githubProfileUrl}
+        onChange={change.bind(null, "githubProfileUrl")}
+        disabled={isSubmitting}
+        fullWidth
+        margin="normal"
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Icon className={clsx("fab fa-github")} />
             </InputAdornment>
           )
         }}

--- a/redi-connect-front/src/pages/front/signup/factory.tsx
+++ b/redi-connect-front/src/pages/front/signup/factory.tsx
@@ -79,6 +79,7 @@ export interface SignUpFormValues {
   personalDescription: string;
   contactEmail: string;
   linkedInProfileUrl: string;
+  githubProfileUrl: string;
   slackUsername: string;
   telephoneNumber: string;
   categories: string[];
@@ -114,6 +115,7 @@ const initialValues: SignUpFormValues = {
   personalDescription: "",
   contactEmail: "",
   linkedInProfileUrl: "",
+  githubProfileUrl: "",
   slackUsername: "",
   telephoneNumber: "",
   categories: [],

--- a/redi-connect-front/src/pages/front/signup/steps/Step4ContactData.tsx
+++ b/redi-connect-front/src/pages/front/signup/steps/Step4ContactData.tsx
@@ -18,6 +18,10 @@ export const validationSchema = Yup.object({
     .max(255)
     .url()
     .label("LinkedIn Profile"),
+  githubProfileUrl: Yup.string()
+    .max(255)
+    .url()
+    .label("Github Profile"),
   slackUsername: Yup.string()
     .max(255)
     .label("Slack username"),
@@ -33,6 +37,7 @@ export const Step4ContactData = (
     values: {
       contactEmail,
       linkedInProfileUrl,
+      githubProfileUrl,
       slackUsername,
       telephoneNumber
     },
@@ -120,6 +125,24 @@ export const Step4ContactData = (
           startAdornment: (
             <InputAdornment position="start">
               <PhoneIcon />
+            </InputAdornment>
+          )
+        }}
+      />
+      <TextField
+        id="githubProfileUrl"
+        name="githubProfileUrl"
+        helperText={touched.githubProfileUrl ? errors.githubProfileUrl : ""}
+        error={touched.githubProfileUrl && Boolean(errors.githubProfileUrl)}
+        label="LinkedIn Profile"
+        value={githubProfileUrl}
+        onChange={change.bind(null, "githubProfileUrl")}
+        fullWidth
+        margin="normal"
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Icon className={clsx("fab fa-github")} />
             </InputAdornment>
           )
         }}

--- a/redi-connect-front/src/pages/front/signup/steps/Step4ContactData.tsx
+++ b/redi-connect-front/src/pages/front/signup/steps/Step4ContactData.tsx
@@ -134,7 +134,7 @@ export const Step4ContactData = (
         name="githubProfileUrl"
         helperText={touched.githubProfileUrl ? errors.githubProfileUrl : ""}
         error={touched.githubProfileUrl && Boolean(errors.githubProfileUrl)}
-        label="LinkedIn Profile"
+        label="Github Profile"
         value={githubProfileUrl}
         onChange={change.bind(null, "githubProfileUrl")}
         fullWidth

--- a/redi-connect-front/src/types/RedProfile.ts
+++ b/redi-connect-front/src/types/RedProfile.ts
@@ -33,6 +33,7 @@ export type RedProfile = {
   personalDescription: string;
   contactEmail: string;
   linkedInProfileUrl: string;
+  githubProfileUrl: string;
   slackUsername: string;
   telephoneNumber: string;
   categories: Array<string>;


### PR DESCRIPTION
- [x] The Github profile URL appears in <ContactInfo /> (below existing contact info fields)
<img width="610" alt="Screen Shot 2019-11-01 at 12 31 45 PM" src="https://user-images.githubusercontent.com/28733727/68022549-f4003080-fca4-11e9-9c9b-f52330f82d92.png">

- [x] An optional Github field appears in the <Me /> and <Step4ContactData /> forms. In both forms, it appears below the existing telephone number field.
<img width="1223" alt="Screen Shot 2019-11-01 at 12 34 42 PM" src="https://user-images.githubusercontent.com/28733727/68022568-fc586b80-fca4-11e9-8853-2f0b80a7fab3.png">

- [x] The "github-circle" icon is used in the forms and in <ContactInfo />. The icon is imported into the project in the most appropriate way (note: it does not seem to be part of the built-in icon library that ships with material ui)

- [x] The label "Github profile URL" is used in both forms and in <ContactInfo />

- [x] RedProfile schema is updated in redi-connect-front, in redi-connect-backend, and redi-connect-admin (can't seem to find a "schema" for the admin)

- [x] URL validation is applied to the field using the yup validator (see validation of linkedin field for an example)
<img width="347" alt="Screen Shot 2019-11-01 at 12 44 13 PM" src="https://user-images.githubusercontent.com/28733727/68022678-53f6d700-fca5-11e9-91a3-fa47a0e063ed.png">
