### PR TITLE
feat(front): new ui password reset

### DIFF
--- a/redi-connect-front/package.json
+++ b/redi-connect-front/package.json
@@ -50,7 +50,7 @@
     "@types/react-dom": "16.9.1",
     "@types/react-redux": "7.1.4",
     "@types/react-router": "5.1.1",
-    "@types/react-router-dom": "^4.3.5",
+    "@types/react-router-dom": "^5.1.5",
     "@types/yup": "0.26.24",
     "@welldone-software/why-did-you-render": "3.3.7",
     "babel-loader": "^8.0.6",

--- a/redi-connect-front/src/components/atoms/Button.scss
+++ b/redi-connect-front/src/components/atoms/Button.scss
@@ -25,13 +25,14 @@
 
   &--default {
     margin-left: .5rem;
+    margin-bottom: .5rem;
 
     &:after {
       content: '';
       transform: translateZ(-1px);
       position: absolute;
-      top: .5rem;
-      right: .5rem;
+      top: 0.375rem;
+      right: 0.375rem;
       width: calc(100% + 4px);
       height: calc(100% + 4px);
       background-color: $redi-orange-light;

--- a/redi-connect-front/src/components/atoms/FormInput.tsx
+++ b/redi-connect-front/src/components/atoms/FormInput.tsx
@@ -10,6 +10,7 @@ interface Props {
   setFieldTouched: Function
   isSubmitting: boolean
   hasError: boolean
+  disabled?: boolean
 }
 
 function FormInput (props: Props) {
@@ -21,7 +22,8 @@ function FormInput (props: Props) {
     handleChange,
     setFieldTouched,
     isSubmitting,
-    hasError
+    hasError,
+    disabled
   } = props
 
   const onChange = (name: any, e: any) => {
@@ -41,7 +43,7 @@ function FormInput (props: Props) {
           placeholder={placeholder}
           value={value}
           onChange={onChange.bind(null, name)}
-          disabled={isSubmitting}
+          disabled={isSubmitting || disabled}
         />
       </Form.Control>
       {hasError && (

--- a/redi-connect-front/src/pages/front/login/Login.scss
+++ b/redi-connect-front/src/pages/front/login/Login.scss
@@ -1,8 +1,0 @@
-@import "../../../styles/_variables";
-
-.login-form {
-  &__reset-password {
-    text-align: right;
-    font-size: $size-7;
-  }
-}

--- a/redi-connect-front/src/pages/front/login/Login.tsx
+++ b/redi-connect-front/src/pages/front/login/Login.tsx
@@ -12,8 +12,6 @@ import {
 import { history } from '../../../services/history/history'
 import { login, fetchSaveRedProfile } from '../../../services/api/api'
 import { saveAccessToken } from '../../../services/auth/auth'
-
-import './Login.scss'
 import { Columns, Form, Heading } from 'react-bulma-components'
 import Button from '../../../components/atoms/Button'
 
@@ -119,7 +117,7 @@ export default function Login () {
             </Form.Field>
 
             <Form.Field
-              className="login-form__reset-password"
+              className="submit-link submit-link--pre"
               textTransform="uppercase"
             >
               <Link to="/front/reset-password/request-reset-password-email">

--- a/redi-connect-front/src/pages/front/reset-password/RequestResetPasswordEmail.tsx
+++ b/redi-connect-front/src/pages/front/reset-password/RequestResetPasswordEmail.tsx
@@ -1,42 +1,28 @@
 import React from 'react'
-import { LoggedOutLayout } from '../../../layouts/LoggedOutLayout'
+import AccountOperation from '../../../components/templates/AccountOperation'
+import { Columns, Heading, Form } from 'react-bulma-components'
+import Teaser from '../../../components/molecules/Teaser'
+import FormInput from '../../../components/atoms/FormInput'
+import Button from '../../../components/atoms/Button'
+
 import {
-  Link,
-  Button,
-  Typography,
-  useTheme,
-  Container,
-  InputAdornment
-} from '@material-ui/core'
-import { Email as EmailIcon } from '@material-ui/icons'
-import { Form, Field } from 'react-final-form'
-import { TextField } from 'final-form-material-ui'
+  FormikValues,
+  useFormik
+} from 'formik'
+
 import * as yup from 'yup'
-import {
-  yupErrorToSimpleObject,
-  ErrorSimpleObject
-} from '../../../utils/yup-error-to-simple-object'
-import { makeStyles } from '@material-ui/styles'
-import { Link as RouterLink } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import {
   showNotification
 } from '../../../components/AppNotification'
 import { requestResetPasswordEmail } from '../../../services/api/api'
 
-const useStyles = (props: any) => {
-  const theme = useTheme()
-  return makeStyles({
-    heading: {
-      margin: theme.spacing(5)
-    },
-    elementsBelowFormTopMargin: {
-      marginTop: theme.spacing(6)
-    }
-  })(props)
+interface FormValues {
+  email: string
 }
 
-interface FormValues {
-  email?: string
+const initialValues: FormValues = {
+  email: ''
 }
 
 const validationSchema = yup.object().shape({
@@ -46,22 +32,8 @@ const validationSchema = yup.object().shape({
     .required('Please provide an email address.')
 })
 
-const validateForm = async (
-  values: FormValues
-): Promise<ErrorSimpleObject> => {
-  try {
-    await validationSchema.validate(values, { abortEarly: false })
-    return {}
-  } catch (err) {
-    const finalFormCompatibleErrors = yupErrorToSimpleObject(err)
-    return finalFormCompatibleErrors
-  }
-}
-
 export const RequestResetPasswordEmail = (props: any) => {
-  const styleClasses = useStyles(props)
-
-  const onSubmit = async (values: FormValues) => {
+  const onSubmit = async (values: FormikValues) => {
     try {
       // Cast to string is safe as this only called if validated
       await requestResetPasswordEmail(values.email as string)
@@ -88,70 +60,67 @@ export const RequestResetPasswordEmail = (props: any) => {
     )
   }
 
+  const formik = useFormik({
+    initialValues: initialValues,
+    validationSchema,
+    onSubmit: onSubmit
+  })
+
   return (
-    <LoggedOutLayout>
-      <Container maxWidth="sm">
-        <Typography
-          variant="h5"
-          align="center"
-          className={styleClasses.heading}
+    <AccountOperation>
+      <Columns vCentered>
+        <Columns.Column
+          size={6}
+          responsive={{ mobile: { hide: { value: true } } }}
         >
-          Reset your password
-        </Typography>
-        <p>
-          Just let us know the email you use to sign in to ReDI Connect and
-          we’ll help you get your password back.
-        </p>
-        <Form
-          onSubmit={onSubmit}
-          validate={validateForm}
-          render={({
-            handleSubmit,
-            submitting: isSubmitting,
-            values,
-            errors,
-            valid: isValid
-          }) => (
-            <form onSubmit={handleSubmit} noValidate>
-              <Field
-                fullWidth
-                id="email"
-                name="email"
-                component={TextField}
-                disabled={isSubmitting}
-                type="text"
-                label="Email"
-                margin="normal"
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <EmailIcon />
-                    </InputAdornment>
-                  )
-                }}
-              />
+          <Teaser.SignUp />
+        </Columns.Column>
+        <Columns.Column size={5} offset={1}>
+          <Heading
+            size={1}
+            responsive={{ mobile: { textSize: { value: 2 } } } }
+            weight="normal"
+            renderAs="h1"
+            className="title--border"
+            spaced={true}
+          >
+            Forgot your password?
+          </Heading>
+          <Heading size={4} renderAs="p" subtitle>
+            We’ll help you reset it and get back on track. We will send a recovery link to:
+          </Heading>
+          <form onSubmit={e => e.preventDefault()} noValidate>
+            <FormInput
+              name="email"
+              type="email"
+              value={formik.values.email}
+              placeholder="Email"
+              setFieldTouched={formik.setFieldTouched}
+              handleChange={formik.handleChange}
+              isSubmitting={formik.isSubmitting}
+              hasError={!!formik.touched.email && !!formik.errors.email}
+            />
+            <Form.Field className="submit-spacer">
               <Button
-                onClick={() => isValid && handleSubmit()}
-                type="submit"
-                color="primary"
-                variant="contained"
                 fullWidth
-                disabled={isSubmitting}
+                onClick={formik.submitForm}
+                disabled={!(formik.dirty && formik.isValid)}
               >
-                Send Password Reset Email
+                Reset Password
               </Button>
-            </form>
-          )}
-        />
-        <Typography
-          align="center"
-          className={styleClasses.elementsBelowFormTopMargin}
-        >
-          <Link component={RouterLink} to="/front/login">
-            Take me back to log in
-          </Link>
-        </Typography>
-      </Container>
-    </LoggedOutLayout>
+            </Form.Field>
+
+            <Form.Field
+              className="submit-link submit-link--post"
+              textTransform="uppercase"
+            >
+              <Link to="/front/login">
+                Back to log in
+              </Link>
+            </Form.Field>
+          </form>
+        </Columns.Column>
+      </Columns>
+    </AccountOperation>
   )
 }

--- a/redi-connect-front/src/pages/front/reset-password/SetNewPassword.tsx
+++ b/redi-connect-front/src/pages/front/reset-password/SetNewPassword.tsx
@@ -1,22 +1,19 @@
 import React, { useState, useEffect } from 'react'
-import { LoggedOutLayout } from '../../../layouts/LoggedOutLayout'
+import AccountOperation from '../../../components/templates/AccountOperation'
+import Teaser from '../../../components/molecules/Teaser'
+import { Columns, Heading, Form } from 'react-bulma-components'
+import Button from '../../../components/atoms/Button'
+
+import FormInput from '../../../components/atoms/FormInput'
+import { Link } from 'react-router-dom'
+
 import * as Yup from 'yup'
+
 import {
-  TextField,
-  InputAdornment,
-  Button,
-  Paper,
-  Container,
-  Typography,
-  makeStyles,
-  useTheme
-} from '@material-ui/core'
-import { Lock as LockIcon } from '@material-ui/icons'
-import {
-  Formik,
   FormikProps,
   FormikHelpers as FormikActions,
-  FormikValues
+  FormikValues,
+  useFormik
 } from 'formik'
 import { history } from '../../../services/history/history'
 import {
@@ -26,37 +23,6 @@ import {
 import { saveAccessToken } from '../../../services/auth/auth'
 import { RouteComponentProps } from 'react-router'
 import { showNotification } from '../../../components/AppNotification'
-
-const useStyles = (props: any) => {
-  const theme = useTheme()
-  return makeStyles({
-    heading: {
-      margin: theme.spacing(5)
-    },
-    elementsBelowFormTopMargin: {
-      marginTop: theme.spacing(6)
-    },
-    formError: {
-      padding: theme.spacing(1),
-      backgroundColor: theme.palette.error.main,
-      color: 'white'
-    },
-    paragraph: {
-      fontWeight: 300
-    },
-    paragraphBelowSubheader: {
-      marginTop: '0.3em',
-      fontWeight: 300
-    },
-    subHeader: {
-      marginBottom: 0
-    },
-    error: {
-      backgroundColor: theme.palette.error.main,
-      color: 'white'
-    }
-  })(props)
-}
 
 interface SetNewPasswordValues {
   password: string
@@ -83,8 +49,6 @@ interface RouteParams {
 }
 
 export const SetNewPassword = (props: RouteComponentProps<RouteParams>) => {
-  const styleClasses = useStyles(props)
-
   const [formError, setFormError] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(false)
   const [errorMsg, setErrorMsg] = useState<string>('')
@@ -97,16 +61,20 @@ export const SetNewPassword = (props: RouteComponentProps<RouteParams>) => {
       try {
         accessToken = JSON.parse(accessTokenStr)
         saveAccessToken(accessToken)
+        console.log('savetoken')
       } catch (err) {
-        console.log('test')
+        console.log('savetoken errp')
         return setErrorMsg(
           'Sorry, there seems to have been an error. Please try to reset your password again, or contact career@redi-school.org for assistance.'
         )
       }
       try {
         await fetchSaveRedProfile(accessToken)
+        console.log('saveprofile')
         setLoading(false)
       } catch (err) {
+        console.log('saveprofile error')
+
         return setErrorMsg(
           'Sorry, the link you used seems to have expired. Please contact career@redi-school.org to receive a new one.'
         )
@@ -132,118 +100,97 @@ export const SetNewPassword = (props: RouteComponentProps<RouteParams>) => {
     actions.setSubmitting(false)
   }
 
+  const formik = useFormik({
+    initialValues: initialValues,
+    validationSchema,
+    onSubmit: submitForm
+  })
+
   return (
-    <LoggedOutLayout>
-      {errorMsg && (
-        <Paper className={styleClasses.error}>
-          <p>{errorMsg}</p>
-          <p>
+    <AccountOperation>
+      <Columns vCentered>
+        <Columns.Column
+          size={6}
+          responsive={{ mobile: { hide: { value: true } } }}
+        >
+          <Teaser.SignUp />
+        </Columns.Column>
+        <Columns.Column size={5} offset={1}>
+
+          <Heading
+            size={1}
+            responsive={{ mobile: { textSize: { value: 2 } } } }
+            weight="normal"
+            renderAs="h1"
+            className="title--border"
+            spaced={true}
+          >
+                Enter your new password
+          </Heading>
+          <Heading size={4} renderAs="p" subtitle>
+                Please make sure that your new password has more than 8 characters.
+          </Heading>
+
+          {formError && (
+            { formError }
+          )}
+          <form onSubmit={e => e.preventDefault()}>
+            <FormInput
+              name="password"
+              type="password"
+              value={formik.values.password}
+              placeholder="Password"
+              setFieldTouched={formik.setFieldTouched}
+              handleChange={formik.handleChange}
+              isSubmitting={formik.isSubmitting}
+              hasError={!!formik.touched.password && !!formik.errors.password}
+              disabled={!!errorMsg}
+            />
+
+            <FormInput
+              name="passwordConfirm"
+              type="password"
+              value={formik.values.passwordConfirm}
+              placeholder="Repeat password"
+              setFieldTouched={formik.setFieldTouched}
+              handleChange={formik.handleChange}
+              isSubmitting={formik.isSubmitting}
+              hasError={!!formik.touched.passwordConfirm && !!formik.errors.passwordConfirm}
+              disabled={!!errorMsg}
+            />
+
+            {errorMsg && (
+              <div>
+                <p>{errorMsg}</p>
+                <p>
             You can also go here{' '}
-            <a href="/front/login">to log in if you have a user.</a>
-          </p>
-        </Paper>
-      )}
-      {!loading && !errorMsg && (
-        <Formik
-          initialValues={initialValues}
-          validationSchema={validationSchema}
-          onSubmit={submitForm}
-          render={props => <Form {...props} formError={formError} />}
-        />
-      )}
-    </LoggedOutLayout>
+                  <a href="/front/login">to log in if you have a user.</a>
+                </p>
+              </div>
+            )}
+
+            <Form.Field className="submit-spacer">
+              <Button
+                fullWidth
+                onClick={formik.submitForm}
+                disabled={!(formik.dirty && formik.isValid)}
+              >
+                Set your new password
+              </Button>
+            </Form.Field>
+
+            <Form.Field
+              className="submit-link submit-link--post"
+              textTransform="uppercase"
+            >
+              <Link to="/front/login">
+                Back to log in
+              </Link>
+            </Form.Field>
+          </form>
+        </Columns.Column>
+      </Columns>
+    </AccountOperation>
   )
 }
 export default SetNewPassword
-
-const Form = (
-  props: FormikProps<SetNewPasswordValues> & {
-    formError: string
-  }
-) => {
-  const {
-    formError,
-    values: { password, passwordConfirm },
-    errors,
-    touched,
-    handleChange,
-    isValid,
-    isSubmitting,
-    setFieldTouched,
-    submitForm
-  } = props
-
-  const styleClasses = useStyles(props)
-
-  const change = (name: any, e: any) => {
-    e.persist()
-    handleChange(e)
-    setFieldTouched(name, true, false)
-  }
-
-  return (
-    <Container maxWidth="sm">
-      <Typography variant="h5" align="center" className={styleClasses.heading}>
-        Reset Your Password
-      </Typography>
-      <p>
-        Nearly there, just enter your new password and you’ll be ReDI Connectin'
-        again in seconds...
-      </p>
-      {formError && (
-        <Paper className={styleClasses.formError}>{formError}</Paper>
-      )}
-      <form onSubmit={e => e.preventDefault()}>
-        <TextField
-          id="password"
-          name="password"
-          type="password"
-          helperText={touched.password ? errors.password : ''}
-          error={touched.password && Boolean(errors.password)}
-          label="Password*"
-          value={password}
-          onChange={change.bind(null, 'password')}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <LockIcon />
-              </InputAdornment>
-            )
-          }}
-          fullWidth
-          margin="normal"
-          disabled={isSubmitting}
-        />
-        <TextField
-          id="passwordConfirm"
-          name="passwordConfirm"
-          type="password"
-          helperText={touched.passwordConfirm ? errors.passwordConfirm : ''}
-          error={touched.passwordConfirm && Boolean(errors.passwordConfirm)}
-          label="Repeat password*"
-          value={passwordConfirm}
-          onChange={change.bind(null, 'passwordConfirm')}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <LockIcon />
-              </InputAdornment>
-            )
-          }}
-          fullWidth
-          margin="normal"
-        />
-        <Button
-          onClick={submitForm}
-          type="submit"
-          color="primary"
-          variant="contained"
-          fullWidth
-          disabled={isSubmitting || !isValid}
-        >
-          Set your new password
-        </Button>
-      </form>
-    </Container>
-  )
-}

--- a/redi-connect-front/src/pages/front/signup-existing/ResetPassword.tsx
+++ b/redi-connect-front/src/pages/front/signup-existing/ResetPassword.tsx
@@ -4,12 +4,13 @@ import * as Yup from 'yup'
 import {
   TextField,
   InputAdornment,
-  Button,
   Paper,
   Theme,
   createStyles,
   withStyles
 } from '@material-ui/core'
+import Button from '../../../components/atoms/Button'
+
 import { Lock as LockIcon } from '@material-ui/icons'
 import {
   Formik,
@@ -152,9 +153,6 @@ const Form = withStyles(styles)(
           />
           <Button
             onClick={submitForm}
-            type="submit"
-            color="primary"
-            variant="contained"
             fullWidth
             disabled={isSubmitting || !isValid}
           >

--- a/redi-connect-front/src/services/api/api.tsx
+++ b/redi-connect-front/src/services/api/api.tsx
@@ -88,6 +88,7 @@ export const fetchSaveRedProfile = async (
     localStorageSaveRedProfile(profile)
     return profile
   } catch (err) {
+    console.log('trowing')
     throw new Error("I'm throwing an error")
   }
 }

--- a/redi-connect-front/src/styles/_forms.scss
+++ b/redi-connect-front/src/styles/_forms.scss
@@ -1,0 +1,14 @@
+@import "./_variables";
+.submit {
+    &-link {
+        font-size: $size-7;
+
+        &--pre {
+            text-align: right;
+        }
+
+        &--post {
+            text-align: center;
+        }
+    }
+}

--- a/redi-connect-front/src/styles/main.scss
+++ b/redi-connect-front/src/styles/main.scss
@@ -4,6 +4,7 @@
 //custom modifiers
 @import "_fonts.scss";
 @import "_heading.scss";
+@import "_forms.scss";
 
 // bulma global dependencies
 @import "~bulma/sass/utilities/_all";

--- a/redi-connect-front/yarn.lock
+++ b/redi-connect-front/yarn.lock
@@ -1994,10 +1994,10 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
-"@types/react-router-dom@^4.3.5":
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.5.tgz#72f229967690c890d00f96e6b85e9ee5780db31f"
-  integrity sha512-eFajSUASYbPHg2BDM1G8Btx+YqGgvROPIg6sBhl3O4kbDdYXdFdfrgQFf/pcBuQVObjfT9AL/dd15jilR5DIEA==
+"@types/react-router-dom@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.5.tgz#7c334a2ea785dbad2b2dcdd83d2cf3d9973da090"
+  integrity sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==
   dependencies:
     "@types/history" "*"
     "@types/react" "*"


### PR DESCRIPTION
Adding the new UI for the password request flow. 
The error handling is not changed, as the design is missing so I left the original app notifications in there. There will be a follow up task there to handle those features when the design is delivered. 
