### PR TITLE
fix(front): fix modal scrolling

### DIFF
--- a/redi-connect-front/src/components/molecules/Modal.scss
+++ b/redi-connect-front/src/components/molecules/Modal.scss
@@ -2,6 +2,11 @@
 
 .modal {
   // not the nicest overwrite but the less ugly one
+  &-open {
+    height: 100vh;
+    overflow-y: hidden;
+  }
+
   &-close {
     position: absolute;
     top: -2.5rem;
@@ -22,8 +27,18 @@
     border-bottom: 1px solid $grey-light;
   }
 
-  .modal-content {
+  &-content {
     overflow: visible;
+  }
+
+  &-container {
+    z-index: 100;
+    position: fixed;
+  }
+
+  &__box {
+    height: 100%;
+    overflow: auto;
   }
 
   &__buttons {

--- a/redi-connect-front/src/components/molecules/Modal.tsx
+++ b/redi-connect-front/src/components/molecules/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useEffect } from 'react'
 import { Heading } from '../atoms'
 import { Box, Modal as BulmaModal } from 'react-bulma-components'
 import './Modal.scss'
@@ -13,7 +13,7 @@ interface Props {
 
 const Buttons: React.FunctionComponent = ({ children }) => (
   <div className="modal__buttons">
-    { children }
+    {children}
   </div>
 )
 
@@ -21,6 +21,10 @@ const Modal = ({ title, children, stateFn, show, confirm }: Props) => {
   const setShowModal = stateFn
     ? () => stateFn(false)
     : undefined
+
+  useEffect(() => {
+    document.body.classList.toggle('modal-open', show)
+  }, [show])
 
   return <BulmaModal
     show={show}
@@ -30,7 +34,7 @@ const Modal = ({ title, children, stateFn, show, confirm }: Props) => {
     closeOnBlur={!confirm}
   >
     <BulmaModal.Content>
-      <Box>
+      <Box className="modal__box">
         {!confirm && <button
           type="button"
           onClick={setShowModal}

--- a/redi-connect-front/src/components/organisms/ApplyForMentor.tsx
+++ b/redi-connect-front/src/components/organisms/ApplyForMentor.tsx
@@ -56,11 +56,10 @@ const ApplyForMentor = ({ mentor, profilesFetchOneStart }: Props) => {
     setSubmitResult('submitting')
     try {
       await requestMentorship(values.applicationText, values.expectationText, mentor.id)
+      setShow(false)
       profilesFetchOneStart(mentor.id)
     } catch (error) {
       setSubmitResult('error')
-    } finally {
-      actions.setSubmitting(false)
     }
   }
 
@@ -121,7 +120,7 @@ const ApplyForMentor = ({ mentor, profilesFetchOneStart }: Props) => {
               checked={formik.values.dataSharingAccepted}
               {...formik}
             >
-                  I understand that my profile data will be shared with this mentor
+              I understand that my profile data will be shared with this mentor
             </Checkbox.Form>
 
             <Modal.Buttons>

--- a/redi-connect-front/src/styles/_variables.scss
+++ b/redi-connect-front/src/styles/_variables.scss
@@ -100,3 +100,8 @@ $card-content-padding: 1rem;
 $card-shadow: 0 3px 15px 0 rgba(0, 0, 0, 0.05),
 0 2px 4px -1px rgba(0, 0, 0, 0.2);
 $card-shadow-hover: 0 6px 20px 3px rgba(111, 119, 121, 0.23);
+
+
+// modaal
+$modal-content-spacing-mobile: 100px;
+$modal-content-spacing-tablet: 100px;


### PR DESCRIPTION
Currently there is a bug with the modal which is making it impossible to scroll the modal content it self on small screens where the content is longer than the screen size.

The bug is testable on the find the mentor page when you open a mentor profile and trigger the apply for mentorship overlay. 

I already deployed the fixed version to the Berlin staging. The Munich stayed the same so you can see the bug. 

This is the fix for it, if you are fine with it it would be also good to release this. 

Cheers,
Endre