### PR TITLE
fix(front): underline on hover in safari removed

### DIFF
--- a/redi-connect-front/src/components/atoms/Logo.tsx
+++ b/redi-connect-front/src/components/atoms/Logo.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as RediLogoMobile } from '../../assets/images/logo-mobil
 
 const Logo = () => {
   return (
-    <NavLink to="/">
+    <NavLink to="/" className="navbar__logo">
       <Element responsive={{ mobile: { hide: { value: true } } }}>
         <RediLogo />
       </Element>

--- a/redi-connect-front/src/components/organisms/Navbar.scss
+++ b/redi-connect-front/src/components/organisms/Navbar.scss
@@ -16,6 +16,10 @@
     }
   }
 
+  &__logo:hover {
+    text-decoration: none !important;
+  }
+
   &__buttons {
     display: flex;
     align-items: center;

--- a/redi-connect-front/src/components/organisms/Navbar.scss
+++ b/redi-connect-front/src/components/organisms/Navbar.scss
@@ -16,6 +16,8 @@
     }
   }
 
+  // since the default a:hover behaviour is defined as underline (main.scss) we had
+  // to define this class for the logo and the !important explictly for safari browser
   &__logo:hover {
     text-decoration: none !important;
   }


### PR DESCRIPTION
Just a quick fix to remove the hover effect (underline) in Safari