### PR TITLE
fix(front): if info is not given it won't be visible in the profile

### DIFF
--- a/redi-connect-front/src/pages/app/profile/Profile.tsx
+++ b/redi-connect-front/src/pages/app/profile/Profile.tsx
@@ -32,7 +32,7 @@ interface ProfileProps {
   profilesFetchOneStart: Function
 }
 
-function Profile({ profile, currentUser, hasReachedMenteeLimit, profilesFetchOneStart }: ProfileProps) {
+function Profile ({ profile, currentUser, hasReachedMenteeLimit, profilesFetchOneStart }: ProfileProps) {
   const { profileId } = useParams<RouteParams>()
   const history = useHistory()
 
@@ -124,13 +124,13 @@ function Profile({ profile, currentUser, hasReachedMenteeLimit, profilesFetchOne
           </Columns.Column>
         </Columns>
 
-        {(profile.personalDescription || profile.expectations || profile.menteeCountCapacity) &&
+        {(profile.personalDescription || profile.expectations) &&
           <Element className="block-separator">
             <ReadAbout.Some profile={profile} />
           </Element>
         }
 
-        {profile.categories &&
+        {profile.categories?.length > 0 &&
           <Element className="block-separator">
             <ReadMentoringTopics.Some profile={profile} />
           </Element>


### PR DESCRIPTION
Since you are both not working on it atm and I'm on my sabbatical for at least a month from tomorrow ongoing I requested both of you ... whoever is first 😄 

In the end it was a small fix that should solve the issue to not just see an empty headline if there is no information given be the mentor / mentee who owns the profile.