### PR TITLE
fix: redirects http to https on static website

### DIFF
--- a/redi-connect-infrastructure/README.md
+++ b/redi-connect-infrastructure/README.md
@@ -79,6 +79,13 @@ Run the az acr show command to retrieve credentials for the registry:
 az acr credential show --resource-group AppSvc-DockerTutorial-rg --name <registry-name>
 ```
 
+## Caveats on terraform code
+
+### custom cdn endpoints are not supported
+
+https://github.com/terraform-providers/terraform-provider-azurerm/issues/398
+That means the user needs to add a custom cdn via the cli.
+
 ----
 
 Resources: 

--- a/redi-connect-infrastructure/README.md
+++ b/redi-connect-infrastructure/README.md
@@ -81,10 +81,13 @@ az acr credential show --resource-group AppSvc-DockerTutorial-rg --name <registr
 
 ## Caveats on terraform code
 
-### custom cdn endpoints are not supported
+- custom cdn endpoints are not supported
 
-https://github.com/terraform-providers/terraform-provider-azurerm/issues/398
-That means the user needs to add a custom cdn via the cli.
+    At the moment the module for terraform isnt supporting custom cdn domains as shown in the issue bellow.
+    
+    https://github.com/terraform-providers/terraform-provider-azurerm/issues/398
+    
+    A workaround in the meantime would be to add a custom cdn via the Azure cli.
 
 ----
 

--- a/redi-connect-infrastructure/_main.tf
+++ b/redi-connect-infrastructure/_main.tf
@@ -67,6 +67,21 @@ resource "azurerm_cdn_endpoint" "cdn-endpoint" {
     name      = "websiteorginaccount"
     host_name = azurerm_storage_account.static_storage.primary_web_host
   }
+
+  delivery_rule {
+    name  = "EnforceHTTPS"
+    order = "1"
+
+    request_scheme_condition {
+      operator     = "Equal"
+      match_values = ["HTTP"]
+    }
+
+    url_redirect_action {
+      redirect_type = "Found"
+      protocol      = "Https"
+    }
+  }
 }
 
 

--- a/redi-connect-infrastructure/_main.tf
+++ b/redi-connect-infrastructure/_main.tf
@@ -22,11 +22,11 @@ locals {
 //}
 
 resource "azurerm_storage_account" "static_storage" {
-  name                = "storagefront${local.env_prefix_no_separator}"
-  resource_group_name = local.resource-group-name
-  location            = local.resource-group-location
   //  resource_group_name       = azurerm_resource_group.webapp-rg.name
   //  location                  = azurerm_resource_group.webapp-rg.location
+  name                      = "storagefront${local.env_prefix_no_separator}"
+  resource_group_name       = local.resource-group-name
+  location                  = local.resource-group-location
   account_kind              = "StorageV2"
   account_tier              = "Standard"
   account_replication_type  = "GRS"
@@ -47,19 +47,19 @@ resource "azurerm_storage_account" "static_storage" {
 # CDN profile and endpoint to static website
 #----------------------------------------------------------
 resource "azurerm_cdn_profile" "cdn-profile" {
-  name = "cdn-profile-front-${local.env_prefix}"
   //  resource_group_name = azurerm_resource_group.webapp-rg.name
+  name                = "cdn-profile-front-${local.env_prefix}"
   resource_group_name = local.resource-group-name
-  location            = var.location_europe
+  location            = var.location_europe # accepts only this location
   sku                 = "Standard_Microsoft"
 }
 
 resource "azurerm_cdn_endpoint" "cdn-endpoint" {
-  name         = "cdn-endpoint-front-${local.env_prefix}"
-  profile_name = azurerm_cdn_profile.cdn-profile.name
   //  resource_group_name           = azurerm_resource_group.webapp-rg.name
+  name                          = "cdn-endpoint-front-${local.env_prefix}"
+  profile_name                  = azurerm_cdn_profile.cdn-profile.name
   resource_group_name           = local.resource-group-name
-  location                      = var.location_europe
+  location                      = var.location_europe # accepts only this location
   origin_host_header            = azurerm_storage_account.static_storage.primary_web_host
   querystring_caching_behaviour = "IgnoreQueryString"
 
@@ -91,20 +91,23 @@ resource "azurerm_cdn_endpoint" "cdn-endpoint" {
 resource "azurerm_container_registry" "acr" {
   name                = "registry${local.env_prefix_no_separator}"
   resource_group_name = local.resource-group-name
-  location            = var.location_europe
+  location            = var.location
   sku                 = var.tier
   admin_enabled       = true
 }
 
 resource "azurerm_cosmosdb_account" "db" {
   name                = "cosmos-${local.env_prefix}"
-  location            = var.location_europe
+  location            = var.location
   resource_group_name = local.resource-group-name
   offer_type          = "Standard"
   kind                = "MongoDB"
 
   enable_automatic_failover = true
 
+  capabilities {
+    name = "EnableMongo"
+  }
   capabilities {
     name = "MongoDBv3.4"
   }
@@ -116,7 +119,7 @@ resource "azurerm_cosmosdb_account" "db" {
   }
 
   geo_location {
-    location          = var.location_europe
+    location          = var.location
     failover_priority = 0
   }
 }


### PR DESCRIPTION
Fixes https://github.com/talent-connect/connect/issues/234

Now you can visit http://cdn-endpoint-front-staging-redi.azureedge.net/front/home which will redirect you to `https`