### PR TITLE
Backend feature flag to use `https` instead of default `http`

### DIFF
--- a/redi-connect-backend/server/server.js
+++ b/redi-connect-backend/server/server.js
@@ -70,9 +70,6 @@ app.use(
 boot(app, __dirname)
 
 app.start = function () {
-  if (httpOnly === undefined) {
-    httpOnly = 
-  }
   const server = (function buildHttpOrHttpsServer(){
     if (process.env.USE_HTTPS) {
       return https.createServer({

--- a/redi-connect-backend/server/server.js
+++ b/redi-connect-backend/server/server.js
@@ -8,6 +8,8 @@ var loopback = require('loopback')
 var boot = require('loopback-boot')
 
 var http = require('http')
+var https = require('https')
+var sslConfig = require('./ssl-config')
 
 var app = (module.exports = loopback())
 /*
@@ -67,14 +69,23 @@ app.use(
 // Sub-apps like REST API are mounted via boot scripts.
 boot(app, __dirname)
 
-app.start = function (httpOnly) {
+app.start = function () {
   if (httpOnly === undefined) {
-    httpOnly = process.env.HTTP
+    httpOnly = 
   }
-  const server = http.createServer(app)
+  const server = (function buildHttpOrHttpsServer(){
+    if (process.env.USE_HTTPS) {
+      return https.createServer({
+        key: sslConfig.privateKey,
+        cert: sslConfig.certificate
+      }, app)
+    } else {
+      return http.crates.createServer(app)
+    }
+  })()
   server.listen(app.get('port'), function () {
     var baseUrl =
-      (httpOnly ? 'http://' : 'https://') +
+      (process.env.USE_HTTPS ? 'https://' : 'http://') +
       app.get('host') +
       ':' +
       app.get('port')


### PR DESCRIPTION
This is a partial revert of #225 that removed the backend's ability to run the backend in https mode using node's `https`, with an SSL cert + private key file hosted on the server-side.

@paschalidi, this is needed for the short while that the backend needs to operate under both Azure and AWS. I see things are more elegant on Azure with SSL provided via some middleware, but nothing similar is set up for the current production backend on AWS. On booting the backend, I'll simply use a USE_HTTPS=1 flag.

Please make sure to check in with me on backend stuff like this. I updated the prod backend to the latest commit, and did a lot of head scratching and taking down the backend, while figuring out what was wrong with my SSL certs, then saw they weren't used at all 😅

Merging immediately as this is basically a hotfix.