### PR TITLE
Add createdAt record for tp job listings

### DIFF
--- a/apps/api/common/models/tp-job-listing.js
+++ b/apps/api/common/models/tp-job-listing.js
@@ -6,6 +6,20 @@ const Rx = require('rxjs')
 const app = require('../../server/server')
 
 module.exports = function (TpJobListing) {
+  TpJobListing.observe('before save', function updateTimestamp(ctx, next) {
+    const currentDate = new Date()
+
+    if (ctx.instance) {
+      if (ctx.isNewInstance) {
+        ctx.instance.createdAt = currentDate
+      }
+      ctx.instance.updatedAt = new Date()
+    } else {
+      ctx.data.updatedAt = new Date()
+    }
+    next()
+  })
+
   TpJobListing.observe('access', function includeStuff(ctx, next) {
     ctx.query.include = ['tpCompanyProfile']
 


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link
Fixes #407 

## What should the reviewer know?
We can also add the createdAt records for previously created job listings, using the trick below:

```
db.TpJobListing.update(
  { _id:ObjectId("__id__")}, 
  { $set: { createdAt: ObjectId('__id__').getTimestamp() } }
)
```