### PR TITLE
Chore/set up volta tooling

### DIFF
--- a/apps/redi-connect/src/pages/front/landing/LocationPicker.tsx
+++ b/apps/redi-connect/src/pages/front/landing/LocationPicker.tsx
@@ -54,7 +54,7 @@ export default function LocationPicker() {
                 {t('loggedOutArea.homePage.hero.about.content2')}
               </Element>
               <Content>
-                <Heading size="medium">Pick your city:</Heading>
+                <Heading size="medium">Pick your location:</Heading>
               </Content>
               {Object.entries(rediLocationNames).map(([key, value]) => (
                 <Button to={`https://connect.${key}.redi-school.org`}>

--- a/package.json
+++ b/package.json
@@ -195,5 +195,8 @@
     "typescript": "~4.1.4",
     "url-loader": "4.1.1",
     "utility-types": "^3.10.0"
+  },
+  "volta": {
+    "node": "14.17.6"
   }
 }


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

This issue sets up [Volta a super-simple helper that ensures we're on the same nodejs version](https://docs.volta.sh/guide/#why-volta).

## What should the reviewer know?

I think you'll find this one useful @helloanil, so you can forget about switching node versions when switching between projects. To set up, just follow the install instructions for volta once, and there you go, you'll _always_ use node v14 in the connect directory.