### PR TITLE
feat(api): prefix demo/dev env email subject lines

### DIFF
--- a/apps/api/lib/email/email.js
+++ b/apps/api/lib/email/email.js
@@ -49,7 +49,7 @@ const sendEmailFactory = (to, subject, body, rediLocation) => {
       },
       Subject: {
         Charset: 'UTF-8',
-        Data: subject,
+        Data: buildSubjectLine(subject, process.env.NODE_ENV),
       },
     },
   })
@@ -64,9 +64,22 @@ const sendMjmlEmailFactory = ({ to, subject, html }) => {
     from: sender,
     to: toSanitized,
     bcc: ['eric@binarylights.com', 'career@redi-school.org'],
-    subject: subject,
+    subject: buildSubjectLine(subject, process.env.NODE_ENV),
     html: html,
   })
+}
+
+function buildSubjectLine(subject, env) {
+  switch (env) {
+    case 'production':
+      return subject
+
+    case 'demonstration':
+      return `[DEMO ENVIRONMENT] ${subject}`
+
+    default:
+      return `[DEV ENVIRONMENT] ${subject}`
+  }
 }
 
 const sendReportProblemEmailTemplate = fs.readFileSync(


### PR DESCRIPTION


## What Github issue does this PR relate to? Insert link.

None

## What should the reviewer know?

I realized this was a quick-win feature, so I went ahead and coded it. 

Emails sent will now be prefixed with `[DEMO ENVIRONMENT]` if sent from the demo env, or with `[DEV ENVIRONMENT]` if working locally. Production emails stay as they are.

This should decrease confusion about where emails are coming from. Especially for Miriam, Johanna & co, now that all emails are bcc-ed to career@redi-school.org.