### PR TITLE
[Issue #459] Enable approving companies without submit

### DIFF
--- a/apps/admin-panel/src/App.jsx
+++ b/apps/admin-panel/src/App.jsx
@@ -1596,7 +1596,7 @@ const TpCompanyProfileEditActions = (props) => {
 
   return (
     <CardActions style={{ display: 'flex', alignItems: 'center' }}>
-      Company profile is pending. Please{' '}
+      Company profile needs to be approved before becoming active. Please{' '}
       <TpCompanyProfileApproveButton {...props} />
     </CardActions>
   )

--- a/apps/admin-panel/src/App.jsx
+++ b/apps/admin-panel/src/App.jsx
@@ -1592,10 +1592,10 @@ const TpJobseekerProfileEditActions = (props) => {
 }
 
 const TpCompanyProfileEditActions = (props) => {
-  if (props?.data?.state !== 'submitted-for-review') return null
+  if (props?.data?.state === 'profile-approved') return null
 
   return (
-    <CardActions>
+    <CardActions style={{ display: 'flex', alignItems: 'center' }}>
       Company profile is pending. Please{' '}
       <TpCompanyProfileApproveButton {...props} />
     </CardActions>

--- a/apps/api/common/models/tp-company-profile.js
+++ b/apps/api/common/models/tp-company-profile.js
@@ -178,16 +178,6 @@ module.exports = function (TpCompanyProfile) {
           )(tpCompanyProfileId)
         )
 
-        const validateCurrentState = switchMap((tpCompanyProfileInst) => {
-          const state = tpCompanyProfileInst.toJSON().state
-          if (state === 'submitted-for-review') {
-            return of(tpCompanyProfileInst)
-          } else {
-            throw new Error(
-              'Invalid current state (is not "submitted-for-review")'
-            )
-          }
-        })
         const setNewTpCompanyProfileProperties = switchMap(
           (tpCompanyProfileInst) =>
             loopbackModelMethodToObservable(
@@ -220,7 +210,6 @@ module.exports = function (TpCompanyProfile) {
         Rx.of({ tpCompanyProfileId })
           .pipe(
             findTpCompanyProfile,
-            validateCurrentState,
             setNewTpCompanyProfileProperties,
             createRoleMapping,
             sendEmailUserReviewedAccepted

--- a/libs/shared-types/src/lib/TpCompanyProfileState.ts
+++ b/libs/shared-types/src/lib/TpCompanyProfileState.ts
@@ -1,3 +1,12 @@
+/**
+ * Although the natural lifecycle of a TpCompanyProfileState
+ * is drafting-ptofile => submitted-for-review => profile-approved,
+ * companies can be approved even if they are not submitted-for-review
+ * yet. (See PR: https://github.com/talent-connect/connect/pull/460).
+ * In some edge cases where companies reach out to a ReDI Admin and
+ * get approved, the TpCompanyProfileState can go from drafting-profile
+ * to profile-approved.
+ */
 export const TpCompanyProfileState = {
   'drafting-profile': 'drafting-profile',
   'submitted-for-review': 'submitted-for-review',


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
Fixes #459 

## What should the reviewer know?
This PR enables Talent Pool Company Profiles to be approved even before they fill the required fields and submit for approval, through Admin Panel. This will allow us to have no issues when two or more recruiters want to use Talent Pool by creating different accounts for the same company.