### PR TITLE
Feat(con): always show applications page for mentors & mentees

### DIFF
--- a/apps/redi-connect/src/components/molecules/ReadOccupation.tsx
+++ b/apps/redi-connect/src/components/molecules/ReadOccupation.tsx
@@ -36,7 +36,7 @@ const ReadOccupation = ({ profile, shortInfo }: Props) => {
   if (!mentor_occupation && !mentee_occupationCategoryId) {
     return (
       <Placeholder>
-        Input your information about your Education and Occupation here.
+        Input your information about your Occupation here.
       </Placeholder>
     )
   }

--- a/apps/redi-connect/src/components/molecules/ReadRediClass.tsx
+++ b/apps/redi-connect/src/components/molecules/ReadRediClass.tsx
@@ -14,12 +14,16 @@ interface Props {
 const ReadRediClass = ({ profile, shortInfo }: Props) => {
   const { mentee_currentlyEnrolledInCourse } = profile
 
+  const COURSES_MAP = Object.fromEntries(
+    COURSES.map((course) => [course.id, course.label])
+  )
+
   return (
     <>
       {shortInfo && <Caption>Redi Class</Caption>}
       <Content>
         {mentee_currentlyEnrolledInCourse && (
-          <p>{COURSES[mentee_currentlyEnrolledInCourse]}</p>
+          <p>{COURSES_MAP[mentee_currentlyEnrolledInCourse]}</p>
         )}
       </Content>
     </>

--- a/apps/redi-connect/src/components/organisms/ApplicationCard.tsx
+++ b/apps/redi-connect/src/components/organisms/ApplicationCard.tsx
@@ -140,7 +140,6 @@ const ApplicationCard = ({
           <>
             <ConfirmMentorship
               match={application}
-              menteeName={profile && profile.firstName}
               hasReachedMenteeLimit={hasReachedMenteeLimit}
             />
             <DeclineMentorshipButton match={application} />

--- a/apps/redi-connect/src/components/organisms/ApplicationCard.tsx
+++ b/apps/redi-connect/src/components/organisms/ApplicationCard.tsx
@@ -23,11 +23,10 @@ interface Props {
 const STATUS_LABELS: any = {
   applied: 'Pending',
   accepted: 'Accepted',
-  completed: 'Completed',
+  completed: 'Accepted',
   cancelled: 'Cancelled',
   'declined-by-mentor': 'Declined',
-  'invalidated-as-other-mentor-accepted':
-    'Invalidated as other mentor accepted',
+  'invalidated-as-other-mentor-accepted': 'Cancelled',
 }
 
 const ApplicationCard = ({
@@ -50,13 +49,22 @@ const ApplicationCard = ({
         onClick={() => setShowDetails(!showDetails)}
       >
         <Columns vCentered>
-          <Columns.Column size={4} className="application-card__avatar">
+          <Columns.Column size={1} className="application-card__avatar">
             <Avatar profile={applicationUser} />
+          </Columns.Column>
+
+          <Columns.Column
+            size={3}
+            textAlignment="left"
+            responsive={{ mobile: { textAlignment: { value: 'centered' } } }}
+          >
             {applicationUser && (
-              <span>
-                {applicationUser.firstName} {applicationUser.lastName} (in{' '}
-                {REDI_LOCATION_NAMES[applicationUser.rediLocation]})
-              </span>
+              <>
+                <p>
+                  {applicationUser.firstName} {applicationUser.lastName}
+                </p>
+                <p>{REDI_LOCATION_NAMES[applicationUser.rediLocation]}</p>
+              </>
             )}
           </Columns.Column>
 

--- a/apps/redi-connect/src/components/organisms/ApplicationCard.tsx
+++ b/apps/redi-connect/src/components/organisms/ApplicationCard.tsx
@@ -22,6 +22,12 @@ interface Props {
 
 const STATUS_LABELS: any = {
   applied: 'Pending',
+  accepted: 'Accepted',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+  'declined-by-mentor': 'Declined',
+  'invalidated-as-other-mentor-accepted':
+    'Invalidated as other mentor accepted',
 }
 
 const ApplicationCard = ({
@@ -130,7 +136,7 @@ const ApplicationCard = ({
             <Content>{application.expectationText}</Content>
           </>
         )}
-        {currentUserIsMentor ? (
+        {currentUserIsMentor && application.status === 'applied' ? (
           <>
             <ConfirmMentorship
               match={application}

--- a/apps/redi-connect/src/components/organisms/ConfirmMentorship.tsx
+++ b/apps/redi-connect/src/components/organisms/ConfirmMentorship.tsx
@@ -46,12 +46,12 @@ const validationSchema = Yup.object({
 // What to replace with instead of below hack?
 const ConfirmMentorship = ({
   match,
-  menteeName,
   hasReachedMenteeLimit,
   matchesAcceptMentorshipStart,
 }: ConfirmMentorshipProps) => {
   const [isModalActive, setModalActive] = useState(false)
   const history = useHistory()
+  const { mentee } = match
 
   //  Keeping this to make sure we address this as its not planned in the desing, yet
   //   <Tooltip> requires child <Button> to be wrapped in a div since it's disabled
@@ -109,7 +109,7 @@ const ConfirmMentorship = ({
             <FormTextArea
               name="mentorReplyMessageOnAccept"
               rows={4}
-              placeholder={`Dear ${menteeName && menteeName}...`}
+              placeholder={`Dear ${mentee.firstName}...`}
               minChar={250}
               maxChar={600}
               {...formik}

--- a/apps/redi-connect/src/components/organisms/ConfirmMentorship.tsx
+++ b/apps/redi-connect/src/components/organisms/ConfirmMentorship.tsx
@@ -51,7 +51,7 @@ const ConfirmMentorship = ({
 }: ConfirmMentorshipProps) => {
   const [isModalActive, setModalActive] = useState(false)
   const history = useHistory()
-  const { mentee } = match
+  const { mentee = { firstName: null } } = match
 
   //  Keeping this to make sure we address this as its not planned in the desing, yet
   //   <Tooltip> requires child <Button> to be wrapped in a div since it's disabled

--- a/apps/redi-connect/src/components/organisms/SideMenu.tsx
+++ b/apps/redi-connect/src/components/organisms/SideMenu.tsx
@@ -34,13 +34,8 @@ const SideMenu = () => {
     profile.userType === 'public-sign-up-mentee-pending-review'
   const isMenteeWithoutMentor =
     isMentee && !profile.ifUserIsMentee_hasActiveMentor
-  const isMentorBookedOut =
-    isActivatedMentor &&
-    profile.currentMenteeCount === profile.menteeCountCapacity
   const isMenteeWithMentor =
     isActivatedMentee && profile.ifUserIsMentee_hasActiveMentor
-
-  const showApplications = isMentee ? isActivatedMentee : !isMentorBookedOut
 
   return (
     <ul className="side-menu">
@@ -63,12 +58,10 @@ const SideMenu = () => {
         </MenuItem>
       )}
 
-      {showApplications && (
-        <MenuItem url="/app/applications">
-          <Applications className="side-menu__icon" />
-          Applications
-        </MenuItem>
-      )}
+      <MenuItem url="/app/applications">
+        <Applications className="side-menu__icon" />
+        Applications
+      </MenuItem>
     </ul>
   )
 }

--- a/apps/redi-connect/src/components/organisms/SideMenu.tsx
+++ b/apps/redi-connect/src/components/organisms/SideMenu.tsx
@@ -40,9 +40,7 @@ const SideMenu = () => {
   const isMenteeWithMentor =
     isActivatedMentee && profile.ifUserIsMentee_hasActiveMentor
 
-  const showApplications = isMentee
-    ? isMenteeWithoutMentor && isActivatedMentee
-    : !isMentorBookedOut
+  const showApplications = isMentee ? isActivatedMentee : !isMentorBookedOut
 
   return (
     <ul className="side-menu">

--- a/apps/redi-connect/src/pages/app/applications/Applications.tsx
+++ b/apps/redi-connect/src/pages/app/applications/Applications.tsx
@@ -18,12 +18,14 @@ function Applications({ applicants }: Props) {
   const history = useHistory()
   const profile = getRedProfileFromLocalStorage()
 
+  console.log('applicants', applicants)
+
   return (
     <LoggedIn>
       <Heading subtitle size="small" className="double-bs">
         Applications {Boolean(applicants.length) && `(${applicants.length})`}
       </Heading>
-      {applicants.length === 0 && (
+      {applicants.length === 0 ? (
         <Content italic>
           {profile.userType === 'mentee' && (
             <>
@@ -41,13 +43,16 @@ function Applications({ applicants }: Props) {
             </>
           )}
         </Content>
-      )}
-      {applicants.length > 0 && (
-        <>
-          {applicants.map((application: RedMatch) => (
+      ) : (
+        applicants
+          .sort((a, b) => {
+            const dateA = new Date(a.createdAt).getTime()
+            const dateB = new Date(b.createdAt).getTime()
+            return dateA < dateB ? 1 : -1
+          })
+          .map((application: RedMatch) => (
             <ApplicationCard key={application.id} application={application} />
-          ))}
-        </>
+          ))
       )}
     </LoggedIn>
   )

--- a/apps/redi-connect/src/pages/app/applications/Applications.tsx
+++ b/apps/redi-connect/src/pages/app/applications/Applications.tsx
@@ -18,7 +18,7 @@ function Applications({ applicants }: Props) {
   const history = useHistory()
   const profile = getRedProfileFromLocalStorage()
 
-  console.log('applicants', applicants)
+  if (profile.userActivated !== true) return <LoggedIn />
 
   return (
     <LoggedIn>

--- a/apps/redi-connect/src/redux/matches/selectors.ts
+++ b/apps/redi-connect/src/redux/matches/selectors.ts
@@ -1,6 +1,5 @@
 import { MatchesState } from './types'
 
-export const getApplicants = (state: MatchesState) =>
-  state.matches.filter((match) => match.status === 'applied')
+export const getApplicants = (state: MatchesState) => state.matches
 export const getMatches = (state: MatchesState) =>
   state.matches.filter((match) => match.status === 'accepted')

--- a/libs/shared-types/src/lib/RedMatch.ts
+++ b/libs/shared-types/src/lib/RedMatch.ts
@@ -23,4 +23,5 @@ export type RedMatch = {
   mentee: RedProfile
   mentorId: string
   menteeId: string
+  createdAt: string
 }


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

#344 and #366

## What should the reviewer know?
In this PR, I also fixed the following:
* placeholder text in the ConfirmMentorship component to be the name of a mentee instead of the name of a mentor
* display ReDI class in the mentee profile

## Screenshots
Non-activated mentee:
![image](https://user-images.githubusercontent.com/51786805/143949896-56073094-7a03-41a6-86d0-302c470ae2d4.png)

Non-activated mentor:
![image](https://user-images.githubusercontent.com/51786805/143949961-83694e25-c0fd-4759-a5b8-9414130a734b.png)

Activated mentee with no applications:
![image](https://user-images.githubusercontent.com/51786805/143950096-ce6abdeb-402b-4718-95ff-3cdb0f1a1b90.png)

Activated mentor with no applications:
![image](https://user-images.githubusercontent.com/51786805/143950254-82736a3b-32d9-49e3-ae81-15ed8ae26144.png)

A user (mentor) with different applications:
![image](https://user-images.githubusercontent.com/51786805/144410598-4a958266-9e06-478e-a71e-495efe5925e4.png)

![image](https://user-images.githubusercontent.com/51786805/144410777-4cc871bc-94ed-4dae-a598-90177c93fe0e.png)

