### PR TITLE
Fix/checkbox without bulma and typed

### DIFF
--- a/libs/shared-atomic-design-components/src/lib/atoms/Checkbox.scss
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Checkbox.scss
@@ -1,5 +1,6 @@
-@import '~bulma/sass/utilities/_all';
 @import '../styles/_variables.scss';
+
+$radius: 4px;
 
 .redi-checkbox {
   position: absolute;

--- a/libs/shared-atomic-design-components/src/lib/atoms/Checkbox.stories.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Checkbox.stories.tsx
@@ -2,7 +2,6 @@ import { Meta } from '@storybook/react/types-6-0'
 import { storybookTemplate } from '../helpers/StorybookTemplate'
 
 import CheckboxComponent from './Checkbox'
-import 'bulma/css/bulma.min.css'
 
 export default {
   title: 'atoms/Checkbox',
@@ -15,4 +14,5 @@ export const Checkbox = template({
   name: 'Checkbox',
   value: 'ABC',
   disabled: false,
+  checked: false
 })

--- a/libs/shared-atomic-design-components/src/lib/atoms/Checkbox.stories.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/react/types-6-0'
+import { ComponentMeta } from '@storybook/react';
 import { storybookTemplate } from '../helpers/StorybookTemplate'
 
 import CheckboxComponent from './Checkbox'
@@ -6,7 +6,15 @@ import CheckboxComponent from './Checkbox'
 export default {
   title: 'atoms/Checkbox',
   component: CheckboxComponent,
-} as Meta
+  argTypes: {
+    handleChange: {
+      control: { type: 'object' }
+    },
+    handleBlur: {
+      control: { type: 'object' }
+    }
+  }
+} as ComponentMeta<typeof CheckboxComponent>
 
 const template = storybookTemplate(CheckboxComponent)
 

--- a/libs/shared-atomic-design-components/src/lib/atoms/Checkbox.stories.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Checkbox.stories.tsx
@@ -13,6 +13,4 @@ const template = storybookTemplate(CheckboxComponent)
 export const Checkbox = template({
   name: 'Checkbox',
   value: 'ABC',
-  disabled: false,
-  checked: false
 })

--- a/libs/shared-atomic-design-components/src/lib/atoms/Checkbox.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Checkbox.tsx
@@ -5,16 +5,18 @@ import './Checkbox.scss'
 
 interface Props {
   name: string
-  value: string
+  value?: string
   checked: boolean
-  children: React.ReactNode
-  disabled: boolean
+  children?: React.ReactNode
+  disabled?: boolean
+  handleChange?: (...args: any[]) => void
+  handleBlur?: (...args: any[]) => void
+  isSubmitting?: boolean
   className?: string
   customOnChange?: Function
 }
 
-// introduce proper types at some point
-function Checkbox(props: any) {
+function Checkbox(props: Props) {
   const {
     name,
     value,

--- a/libs/shared-atomic-design-components/src/lib/helpers/StorybookTemplate.tsx
+++ b/libs/shared-atomic-design-components/src/lib/helpers/StorybookTemplate.tsx
@@ -5,7 +5,7 @@ export const storybookTemplate =
   <TPropsType,>(
     Component: (props: TPropsType) => StoryFnReactReturnType | null
   ) =>
-  (props: TPropsType): Story<TPropsType> => {
+  (props: Partial<TPropsType>): Story<TPropsType> => {
     const template: Story<TPropsType> = (args) => {
       return <Component {...args} />
     }

--- a/libs/shared-atomic-design-components/src/lib/molecules/FilterDropdown.tsx
+++ b/libs/shared-atomic-design-components/src/lib/molecules/FilterDropdown.tsx
@@ -67,6 +67,7 @@ const FilterDropdown = ({
         {items.map((item) => (
           <li key={item.value}>
             <Checkbox
+              name={`${item.value}-checkbox`}
               handleChange={() => onChange(item.value)}
               checked={selected.includes(item.value)}
             >


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

#431

## What should the reviewer know?

The Checkbox component has no internal state, so the Storybook story uses now the properties. Do we want to create a wrapper to handle the 2-way data binding for the checked?