### PR TITLE
Add Job Fair 2022 Toggle for new/edit job posting modal

### DIFF
--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
@@ -250,7 +250,8 @@ function ModalForm({
           handleChange={formik.handleChange}
           {...formik}
         >
-          Advertised at ReDI Job Fair 2022
+          We will recruit for this job listing at the ReDI Job Fair on 11
+          February 2022
         </Checkbox.Form>
 
         <FormInput

--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
@@ -6,6 +6,7 @@ import {
   Heading,
   Icon,
   Modal,
+  Checkbox,
 } from '@talent-connect/shared-atomic-design-components'
 import { TpJobListing, TpJobseekerProfile } from '@talent-connect/shared-types'
 import {
@@ -26,6 +27,7 @@ import { useTpJobListingUpdateMutation } from '../../../react-query/use-tpjoblis
 import { EmptySectionPlaceholder } from '../../molecules/EmptySectionPlaceholder'
 import { JobListingCard } from '../JobListingCard'
 import JobPlaceholderCardUrl from './job-placeholder-card.svg'
+import { get } from 'lodash'
 
 export function EditableJobPostings({
   isJobPostingFormOpen,
@@ -241,6 +243,16 @@ function ModalForm({
         >
           Add the job postings you want to publish to jobseekers at ReDI School.
         </Element>
+        {/* This Checkbox is added only for JobFair 2022. Please remove after 11.02.2022 */}
+        <Checkbox.Form
+          name="isJobFair2022JobListing"
+          checked={get(formik.values, 'isJobFair2022JobListing', false)}
+          handleChange={formik.handleChange}
+          {...formik}
+        >
+          Advertised at ReDI Job Fair 2022
+        </Checkbox.Form>
+
         <FormInput
           name={`title`}
           placeholder="Junior Frontend Developer"

--- a/libs/shared-types/src/lib/TpJobListing.ts
+++ b/libs/shared-types/src/lib/TpJobListing.ts
@@ -11,6 +11,7 @@ export type TpJobListing = {
   languageRequirements?: string
   desiredExperience?: string
   salaryRange?: string
+  isJobFair2022JobListing?: boolean
 
   tpCompanyProfileId?: string
   tpCompanyProfile?: TpCompanyProfile


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

#480

## What should the reviewer know?

This PR adds a simple checkbox to toggle the `isJobFair2022JobListing` field for `TpJobListing` in the page `http://localhost:2999/app/me`. This field will help us filter job listings by their participation status to JF2022.

## Screenshots

<img width="948" alt="image" src="https://user-images.githubusercontent.com/6698585/149986806-46045f86-ea20-4dd5-9435-8a9a45e71bd0.png">
