### PR TITLE
Fix/JobSeekerProfileCard import fails

### DIFF
--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -19,7 +19,7 @@ import {
   useQueryParams,
   withDefault,
 } from 'use-query-params'
-import { JobseekerProfileCard } from '../../../components/organisms/JobSeekerProfileCard'
+import { JobseekerProfileCard } from '../../../components/organisms/JobseekerProfileCard'
 import { LoggedIn } from '../../../components/templates'
 import { useBrowseTpJobseekerProfilesQuery } from '../../../react-query/use-tpjobseekerprofile-query'
 


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Close #486

## What should the reviewer know?

Moving my files under the WSL2/Ubuntu20.04 made this error pop up. I suppose it's because of case sensitivity of the new file system.