### PR TITLE
[#480] Add Job Fair 2022 filter for Jobseekers

### DIFF
--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -1,5 +1,6 @@
 import {
   FilterDropdown,
+  Checkbox,
   Icon,
   SearchField,
 } from '@talent-connect/shared-atomic-design-components'
@@ -9,7 +10,6 @@ import {
   topSkills,
   topSkillsIdToLabelMap,
 } from '@talent-connect/talent-pool/config'
-import React from 'react'
 import { Columns, Element, Tag } from 'react-bulma-components'
 import { useHistory } from 'react-router'
 import {
@@ -28,20 +28,29 @@ export function BrowseCompany() {
     name: withDefault(StringParam, ''),
     skills: withDefault(ArrayParam, []),
     desiredPositions: withDefault(ArrayParam, []),
+    isJobFair2022Participant: withDefault(BooleanParam, undefined),
   })
-  const { name, skills, desiredPositions } = query
+  const { name, skills, desiredPositions, isJobFair2022Participant } = query
 
   const history = useHistory()
   const { data: jobseekerProfiles } = useBrowseTpJobseekerProfilesQuery({
     name,
     skills,
     desiredPositions,
+    isJobFair2022Participant,
   })
 
   const toggleFilters = (filtersArr, filterName, item) => {
     const newFilters = toggleValueInArray(filtersArr, item)
     setQuery((latestQuery) => ({ ...latestQuery, [filterName]: newFilters }))
   }
+
+  const toggleJobFair2022Filter = () =>
+    setQuery((latestQuery) => ({
+      ...latestQuery,
+      isJobFair2022Participant:
+        isJobFair2022Participant === undefined ? true : undefined,
+    }))
 
   const setName = (value) => {
     setQuery((latestQuery) => ({ ...latestQuery, name: value || undefined }))
@@ -52,6 +61,7 @@ export function BrowseCompany() {
       ...latestQuery,
       skills: [],
       desiredPositions: [],
+      isJobFair2022Participant: undefined,
     }))
   }
 
@@ -103,8 +113,19 @@ export function BrowseCompany() {
           />
         </div>
       </div>
+      <div className="filters">
+        <Checkbox
+          name="isJobFair2022Participant"
+          checked={isJobFair2022Participant || false}
+          handleChange={toggleJobFair2022Filter}
+        >
+          Filter by ReDI Job Fair 2022
+        </Checkbox>
+      </div>
       <div className="active-filters">
-        {(skills.length !== 0 || desiredPositions.length !== 0) && (
+        {(skills.length !== 0 ||
+          desiredPositions.length !== 0 ||
+          isJobFair2022Participant) && (
           <>
             {(skills as string[]).map((catId) => (
               <FilterTag
@@ -124,6 +145,14 @@ export function BrowseCompany() {
                 }
               />
             ))}
+            {isJobFair2022Participant && (
+              <FilterTag
+                key="redi-job-fair-2022-filter"
+                id="redi-job-fair-2022-filter"
+                label="ReDI Job Fair 2022"
+                onClickHandler={toggleJobFair2022Filter}
+              />
+            )}
             <span className="active-filters__clear-all" onClick={clearFilters}>
               Delete all filters
               <Icon icon="cancel" size="small" space="left" />

--- a/apps/redi-talent-pool/src/services/api/api.tsx
+++ b/apps/redi-talent-pool/src/services/api/api.tsx
@@ -112,12 +112,14 @@ export interface TpJobseekerProfileFilters {
   name: string
   skills: string[]
   desiredPositions: string[]
+  isJobFair2022Participant: boolean
 }
 
 export async function fetchAllTpJobseekerProfiles({
   name,
   skills: topSkills,
   desiredPositions,
+  isJobFair2022Participant,
 }: TpJobseekerProfileFilters): Promise<Array<Partial<TpJobseekerProfile>>> {
   const filterTopSkills =
     topSkills && topSkills.length !== 0 ? { inq: topSkills } : undefined
@@ -125,6 +127,9 @@ export async function fetchAllTpJobseekerProfiles({
     desiredPositions && desiredPositions.length !== 0
       ? { inq: desiredPositions }
       : undefined
+  const filterJobFair2022Participant = isJobFair2022Participant
+    ? { isJobFair2022Participant: true }
+    : undefined
 
   return http(
     `${API_URL}/tpJobseekerProfiles?filter=${JSON.stringify({
@@ -144,6 +149,7 @@ export async function fetchAllTpJobseekerProfiles({
             })),
           { topSkills: filterTopSkills },
           { desiredPositions: filterDesiredPositions },
+          { ...filterJobFair2022Participant },
         ],
       },
       order: 'createdAt DESC',


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Ref #480 

## What should the reviewer know?

This PR adds a checkbox as a new filter toggle for job seekers, filtering them by `isJobFair2022Participant`

## Screenshots

![tp-filter-jobfair2022-jobseekers](https://user-images.githubusercontent.com/6698585/150218069-04dd455c-2e96-43f9-adc2-fcf3bad4c0e3.gif)

