### PR TITLE
[#480] Add Job Fair 2022 toggle in admin-panel

### DIFF
--- a/apps/admin-panel/src/App.jsx
+++ b/apps/admin-panel/src/App.jsx
@@ -1293,6 +1293,10 @@ const TpJobseekerProfileShow = (props) => (
         <Tab label="Profile">
           <TextField source="state" />
           <BooleanField source="isProfileVisibleToCompanies" />
+          <BooleanField
+            initialValue={false}
+            source="isJobFair2022Participant"
+          />
           <Avatar />
           <TextField source="firstName" />
           <TextField source="lastName" />
@@ -1442,6 +1446,7 @@ const TpJobseekerProfileEdit = (props) => (
       <FormTab label="Profile">
         <TextField source="state" />
         <BooleanInput source="isProfileVisibleToCompanies" />
+        <BooleanInput initialValue={false} source="isJobFair2022Participant" />
         {/* <Avatar /> */}
         <TextInput source="firstName" />
         <TextInput source="lastName" />
@@ -1900,6 +1905,7 @@ const TpJobListingShow = (props) => (
       </ReferenceField>
       <TextField source="title" />
       <TextField source="location" />
+      <BooleanField initialValue={false} source="isJobFair2022JobListing" />
       <TextField source="summary" />
       <TextField source="proficiencyLevelId" />
       <FunctionField
@@ -1930,6 +1936,7 @@ const TpJobListingEdit = (props) => (
       </ReferenceField>
       <TextInput source="title" />
       <TextInput source="location" />
+      <BooleanInput initialValue={false} source="isJobFair2022JobListing" />
       <TextInput source="summary" multiline />
       <TextInput source="proficiencyLevelId" />
       <FunctionField


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Ref #480

## What should the reviewer know?

Toggle in admin-panel for Job Seekers and Job Listings (show/edit).

A remark is that the two `BooleanInput` will save `false` in the record.

As far as I understood we want to be consistent and have `undefined`/`true` in the records.

[react-admin](https://marmelab.com/react-admin) latest version `3.19.5` says we could use [parse](https://marmelab.com/react-admin/Inputs.html#recipes) and `format`.

We use `react-admin` version `2.99` but it _should_ anyway be based on [react-final-form](https://final-form.org/docs/react-final-form/types/FieldProps#parse) which should have `parse`/`format`.

It would be nice to use something like this, but maybe I got it wrong and it does not work for another reason:
```
<BooleanInput 
    initialValue={false}
    parse={(v) => (v === false) ? undefined : v}
    format={(v) => (v == undefined) ? false :  v}
    source="isJobFair2022Participant"
/>
```


## Screenshots

![tp-filter-jobfair2022-jobseekers-admin-panel](https://user-images.githubusercontent.com/6698585/150659188-b5716105-25b1-4e26-bfa8-1bf0eb0ae5a5.gif)

![tp-filter-jobfair2022-joblistings-admin-panel](https://user-images.githubusercontent.com/6698585/150659192-59aa52aa-d396-417a-87e7-391ad946a5b3.gif)

