### PR TITLE
chore(api): fix the 'remove orphaned users' script

### DIFF
--- a/apps/api/scripts/fix-orphaned-red-users.js
+++ b/apps/api/scripts/fix-orphaned-red-users.js
@@ -1,23 +1,36 @@
-const Rx = require('rxjs');
-const _ = require('lodash');
+const Rx = require('rxjs')
+const _ = require('lodash')
 
-const app = require('../server/server');
+const app = require('../server/server')
 
-const { RedProfile, RedUser } = app.models;
+const { RedProfile, RedUser } = app.models
 
-(async () => {
-  const allProfiles = await RedProfile.find({ include: 'redUser' });
-  const allUsers = await RedUser.find({ include: 'redProfile' });
+;(async () => {
+  const allUsers = await RedUser.find({
+    include: ['redProfile', 'tpJobSeekerProfile', 'tpCompanyProfile'],
+  })
 
   // Find orphaned RedUsers
-  const usersWithoutProfile = allUsers.filter((u) => !u.toJSON().redProfile);
+  const usersWithoutProfile = allUsers.filter((u) => {
+    const user = u.toJSON()
+    const hasProfile =
+      Boolean(user.redProfile) ||
+      Boolean(user.tpJobSeekerProfile) ||
+      Boolean(user.tpCompanyProfile)
+    return !hasProfile
+  })
   await usersWithoutProfile.forEach(async (user) => {
-    const userData = user.toJSON();
-    const id = userData.id.toString();
-    await RedUser.destroyById(id, (err) => console.log(err));
-    console.log(`Deleting orphaned RedUser #${id} with email ${userData.email}`);
-  });
+    const userData = user.toJSON()
+    const id = userData.id.toString()
+    const status =
+      `redProfile? ${userData.redProfile ? '✅' : '❌'}` +
+      `\ntpJobseekerProfile? ${userData.tpJobSeekerProfile ? '✅' : '❌'}` +
+      `\ntpCompanyProfile? ${userData.tpCompanyProfile ? '✅' : '❌'}`
+    console.log(
+      `Deleting orphaned RedUser #${id} with email ${userData.email}. ${status}`
+    )
+  })
 
-  console.log(allUsers.length);
-  console.log(allProfiles.length);
-})();
+  console.log(usersWithoutProfile.length)
+  console.log(allUsers.length)
+})()


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

## What should the reviewer know?

This repairs the maintenance scripts that deletes orphaned RedUsers, i.e. users that have don't have any profiles in either Connect or Talent Pool. This script has been out of commission since we launched TP, as it worked for CON only. It now takes care of deleting users what have no profiles whatsoever, and as such are truly orphaned.
