### PR TITLE
Feat/mentoring-topics-revamp

### DIFF
--- a/apps/redi-connect/src/components/organisms/EditableMentoringTopics.tsx
+++ b/apps/redi-connect/src/components/organisms/EditableMentoringTopics.tsx
@@ -121,9 +121,6 @@ const CategoryGroup = ({
   onChange,
   formik,
 }: any) => {
-  // The current REDI_LOCATION might not use the current CategoryGroup (e.g.
-  // Munich doesnt, at the time or writing, use 'coding' or 'other'. If it's the case, return null
-
   if (!categoriesByGroup[id]) return null
   return (
     <Columns.Column size={4}>

--- a/libs/shared-config/src/lib/mentoring-data-lists.ts
+++ b/libs/shared-config/src/lib/mentoring-data-lists.ts
@@ -1,0 +1,12 @@
+export const MENTORING_GOALS = {
+  abc: 'ABC',
+  abc_plus: 'ABC+',
+  abc_plus_plus: 'ABC++',
+  abc_plus_plus_plus: 'ABC+++',
+} as const
+
+export const PROFESSIONAL_EXPERIENCE_FIELDS = {
+  none: 'None',
+  some: 'Some',
+  professional: 'Professional',
+} as const


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

## What should the reviewer know?

We're revamping the mentoring topics, replacing them with four data lists: fields of expertise; mentoring goals; mentoring topics; skills.

This change will be a large one, and will affect the editing, browsing and filtering experience of mentors and mentees.