### PR TITLE
hotfix(api): quick email template fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,16 @@
     "./lib/shared-atomic-design-components",
     "./libs/shared-types"
   ],
-  "typescript.preferences.importModuleSpecifier": "project-relative"
+  "typescript.preferences.importModuleSpecifier": "project-relative",
+  "cSpell.words": [
+    "Deloitte",
+    "Formik",
+    "Jobseeker",
+    "marginless",
+    "mentee",
+    "mentees",
+    "paddingless",
+    "Paulina",
+    "redi"
+  ]
 }


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

## What should the reviewer know?

This a "fork" from #481 to zoom in on specifically code spell checking.

Useful comment from @Paul7Peterson:

> I use spell checkers to avoid a big amount of issues that are coming from that. In the PR can be seen in some places how I was fixing many typing errors that I found because of this. The configuration of glossaries can be done per user or per workspace, but makes no sense to be done for the first.
>
>The words in the glossary (that must be in the .vscode/settings.json file) are not for describing terms in the project, but for including terms that are not recognized per the English and language-specific database of the extension. So the first bullet makes no sense for this specific case, but can be done in a separated .md file without any problem. And the second bullet it's because it's the config of an extension and must go in this specific file. I would also recommend setting a .vscode/extensions.json with the recommendation.
>
>About the documentation of the extension, you can name the recommended extension and set a link to the source documentation, but the use of this extensión is exactly the same as the auto-corrector in word.
