### PR TITLE
Add Federal State field & filtering for Joblistings

### DIFF
--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
@@ -12,6 +12,7 @@ import { TpJobListing, TpJobseekerProfile } from '@talent-connect/shared-types'
 import {
   desiredPositions,
   employmentTypes,
+  germanFederalStates,
   topSkills,
 } from '@talent-connect/talent-pool/config'
 import { useFormik } from 'formik'
@@ -28,6 +29,7 @@ import { EmptySectionPlaceholder } from '../../molecules/EmptySectionPlaceholder
 import { JobListingCard } from '../JobListingCard'
 import JobPlaceholderCardUrl from './job-placeholder-card.svg'
 import { get } from 'lodash'
+import { objectEntries } from '@talent-connect/typescript-utilities'
 
 export function EditableJobPostings({
   isJobPostingFormOpen,
@@ -243,16 +245,6 @@ function ModalForm({
         >
           Add the job postings you want to publish to jobseekers at ReDI School.
         </Element>
-        {/* This Checkbox is added only for JobFair 2022. Please remove after 11.02.2022 */}
-        <Checkbox.Form
-          name="isJobFair2022JobListing"
-          checked={get(formik.values, 'isJobFair2022JobListing', false)}
-          handleChange={formik.handleChange}
-          {...formik}
-        >
-          We will recruit for this job listing at the ReDI Job Fair on 11
-          February 2022
-        </Checkbox.Form>
 
         <FormInput
           name={`title`}
@@ -264,6 +256,12 @@ function ModalForm({
           name={`location`}
           placeholder="Where is the position based"
           label="Location*"
+          {...formik}
+        />
+        <FormSelect
+          name="federalState"
+          label="Location (Federal State in Germany)"
+          items={federalStatesOptions}
           {...formik}
         />
         <FormTextArea
@@ -382,3 +380,10 @@ const formRelatedPositions = desiredPositions.map(({ id, label }) => ({
   value: id,
   label,
 }))
+
+const federalStatesOptions = objectEntries(germanFederalStates).map(
+  ([value, label]) => ({
+    value,
+    label,
+  })
+)

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
@@ -19,6 +19,7 @@ import {
   desiredPositionsIdToLabelMap,
   employmentTypes,
   employmentTypesIdToLabelMap,
+  germanFederalStates,
   topSkills,
   topSkillsIdToLabelMap,
 } from '@talent-connect/talent-pool/config'
@@ -28,6 +29,7 @@ import { useTpJobseekerProfileQuery } from '../../../react-query/use-tpjobseeker
 
 import { LoggedIn } from '../../../components/templates'
 import { JobListingCard } from '../../../components/organisms/JobListingCard'
+import { objectEntries } from '@talent-connect/typescript-utilities'
 
 export function BrowseJobseeker() {
   const [companyName, setCompanyName] = useState('')
@@ -74,6 +76,7 @@ export function BrowseJobseeker() {
       ...latestQuery,
       idealTechnicalSkills: [],
       employmentType: [],
+      federalStates: [],
       isJobFair2022JobListing: undefined,
     }))
   }
@@ -140,6 +143,17 @@ export function BrowseJobseeker() {
             selected={idealTechnicalSkills}
             onChange={(item) =>
               toggleFilters(idealTechnicalSkills, 'idealTechnicalSkills', item)
+            }
+          />
+        </div>
+        <div className="filters-inner">
+          <FilterDropdown
+            items={germanFederalStatesOptions}
+            className="filters__dropdown"
+            label="Federal State"
+            selected={federalStates}
+            onChange={(item) =>
+              toggleFilters(federalStates, 'federalStates', item)
             }
           />
         </div>
@@ -270,3 +284,10 @@ export function toggleValueInArray<T>(array: Array<T>, value: T) {
   if (array.includes(value)) return array.filter((val) => val !== value)
   else return [...array, value]
 }
+
+const germanFederalStatesOptions = objectEntries(germanFederalStates).map(
+  ([value, label]) => ({
+    value,
+    label,
+  })
+)

--- a/apps/redi-talent-pool/src/services/api/api.tsx
+++ b/apps/redi-talent-pool/src/services/api/api.tsx
@@ -302,7 +302,7 @@ export async function fetchAllTpJobListingsUsingFilters({
       : undefined
 
   const filterFederalStates =
-    federalStates && federalStates.length !== 0
+    federalStates?.length !== 0
       ? { inq: federalStates }
       : undefined
 

--- a/apps/redi-talent-pool/src/services/api/api.tsx
+++ b/apps/redi-talent-pool/src/services/api/api.tsx
@@ -301,6 +301,11 @@ export async function fetchAllTpJobListingsUsingFilters({
       ? { inq: employmentType }
       : undefined
 
+  const filterFederalStates =
+    federalStates && federalStates.length !== 0
+      ? { inq: federalStates }
+      : undefined
+
   const filterJobFair2022JobListings = isJobFair2022JobListing
     ? { isJobFair2022JobListing: true }
     : undefined
@@ -317,6 +322,7 @@ export async function fetchAllTpJobListingsUsingFilters({
             relatesToPositions: filterRelatedPositions,
             idealTechnicalSkills: filterIdealTechnicalSkills,
             employmentType: filterDesiredEmploymentTypeOptions,
+            federalState: filterFederalStates,
             ...filterJobFair2022JobListings,
           },
         ],


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
This PR adds a new field for job listings, called `federalState`. This is very similar to what we have done in #516, where we have added the same field for jobseekers.

Using this field, companies will be able to select a specific federal state in Germany when they open a job post, and jobseekers will be able to filter the job listings, using a filter box in the Browse page.

## Screenshots
![CleanShot 2022-03-28 at 10 35 02](https://user-images.githubusercontent.com/6314657/160359096-f4fbc668-ec9c-438a-806c-c59324f81672.png)

![2022-03-28 10 33 59](https://user-images.githubusercontent.com/6314657/160358948-3733eca2-5f1d-4873-a74d-520189157b50.gif)

