### PR TITLE
feat(tp): remove `isJobFair2022JobListing`

### DIFF
--- a/apps/admin-panel/src/App.jsx
+++ b/apps/admin-panel/src/App.jsx
@@ -1967,18 +1967,11 @@ const TpCompanyProfileEdit = (props) => (
   </Edit>
 )
 
-const TpJobListingListFilters = (props) => (
-  <Filter {...props}>
-    <NullableBooleanInput source="isJobFair2022JobListing" />
-  </Filter>
-)
-
 const TpJobListingList = (props) => {
   return (
     <List
       {...props}
       pagination={<AllModelsPagination />}
-      filters={<TpJobListingListFilters />}
       exporter={tpJobListingListExporter}
     >
       <Datagrid>
@@ -2051,7 +2044,6 @@ const TpJobListingShow = (props) => (
       </ReferenceField>
       <TextField source="title" />
       <TextField source="location" />
-      <BooleanField initialValue={false} source="isJobFair2022JobListing" />
       <TextField source="summary" />
       <TextField source="proficiencyLevelId" />
       <FunctionField
@@ -2082,7 +2074,6 @@ const TpJobListingEdit = (props) => (
       </ReferenceField>
       <TextInput source="title" />
       <TextInput source="location" />
-      <BooleanInput initialValue={false} source="isJobFair2022JobListing" />
       <TextInput source="summary" multiline />
       <TextInput source="proficiencyLevelId" />
       <FunctionField

--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
@@ -243,17 +243,6 @@ function ModalForm({
         >
           Add the job postings you want to publish to jobseekers at ReDI School.
         </Element>
-        {/* This Checkbox is added only for JobFair 2022. Please remove after 11.02.2022 */}
-        <Checkbox.Form
-          name="isJobFair2022JobListing"
-          checked={get(formik.values, 'isJobFair2022JobListing', false)}
-          handleChange={formik.handleChange}
-          {...formik}
-        >
-          We will recruit for this job listing at the ReDI Job Fair on 11
-          February 2022
-        </Checkbox.Form>
-
         <FormInput
           name={`title`}
           placeholder="Junior Frontend Developer"

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
@@ -38,14 +38,12 @@ export function BrowseJobseeker() {
     idealTechnicalSkills: withDefault(ArrayParam, []),
     employmentType: withDefault(ArrayParam, []),
     federalStates: withDefault(ArrayParam, []),
-    isJobFair2022JobListing: withDefault(BooleanParam, undefined),
   })
   const {
     relatedPositions,
     idealTechnicalSkills,
     employmentType,
     federalStates,
-    isJobFair2022JobListing,
   } = query
 
   const history = useHistory()
@@ -54,7 +52,6 @@ export function BrowseJobseeker() {
     idealTechnicalSkills,
     employmentType,
     federalStates,
-    isJobFair2022JobListing,
   })
 
   const toggleFilters = (filtersArr, filterName, item) => {
@@ -62,19 +59,11 @@ export function BrowseJobseeker() {
     setQuery((latestQuery) => ({ ...latestQuery, [filterName]: newFilters }))
   }
 
-  const toggleJobFair2022Filter = () =>
-    setQuery((latestQuery) => ({
-      ...latestQuery,
-      isJobFair2022JobListing:
-        isJobFair2022JobListing === undefined ? true : undefined,
-    }))
-
   const clearFilters = () => {
     setQuery((latestQuery) => ({
       ...latestQuery,
       idealTechnicalSkills: [],
       employmentType: [],
-      isJobFair2022JobListing: undefined,
     }))
   }
 
@@ -143,22 +132,12 @@ export function BrowseJobseeker() {
             }
           />
         </div>
-        <div className="filters-inner filters__jobfair2022">
-          <Checkbox
-            name="isJobFair2022JobListing"
-            checked={isJobFair2022JobListing || false}
-            handleChange={toggleJobFair2022Filter}
-          >
-            Filter by ReDI Job Fair 2022
-          </Checkbox>
-        </div>
       </div>
       <div className="active-filters">
         {(relatedPositions.length !== 0 ||
           idealTechnicalSkills.length !== 0 ||
           employmentType.length !== 0 ||
-          federalStates.length !== 0 ||
-          isJobFair2022JobListing) && (
+          federalStates.length !== 0) && (
           <>
             {(relatedPositions as string[]).map((catId) => (
               <FilterTag
@@ -194,13 +173,6 @@ export function BrowseJobseeker() {
                 }
               />
             ))}
-            {isJobFair2022JobListing && (
-              <FilterTag
-                id="redi-job-fair-2022-filter"
-                label="ReDI Job Fair 2022"
-                onClickHandler={toggleJobFair2022Filter}
-              />
-            )}
             <span className="active-filters__clear-all" onClick={clearFilters}>
               Delete all filters
               <Icon icon="cancel" size="small" space="left" />

--- a/apps/redi-talent-pool/src/services/api/api.tsx
+++ b/apps/redi-talent-pool/src/services/api/api.tsx
@@ -276,7 +276,6 @@ export interface TpJobListingFilters {
   idealTechnicalSkills: string[]
   employmentType: string[]
   federalStates: string[]
-  isJobFair2022JobListing: boolean
 }
 
 export async function fetchAllTpJobListingsUsingFilters({
@@ -284,7 +283,6 @@ export async function fetchAllTpJobListingsUsingFilters({
   idealTechnicalSkills,
   employmentType,
   federalStates,
-  isJobFair2022JobListing,
 }: TpJobListingFilters): Promise<Array<TpJobListing>> {
   const filterRelatedPositions =
     relatedPositions && relatedPositions.length !== 0
@@ -301,10 +299,6 @@ export async function fetchAllTpJobListingsUsingFilters({
       ? { inq: employmentType }
       : undefined
 
-  const filterJobFair2022JobListings = isJobFair2022JobListing
-    ? { isJobFair2022JobListing: true }
-    : undefined
-
   return http(
     `${API_URL}/tpJobListings?filter=${JSON.stringify({
       where: {
@@ -317,7 +311,6 @@ export async function fetchAllTpJobListingsUsingFilters({
             relatesToPositions: filterRelatedPositions,
             idealTechnicalSkills: filterIdealTechnicalSkills,
             employmentType: filterDesiredEmploymentTypeOptions,
-            ...filterJobFair2022JobListings,
           },
         ],
       },

--- a/libs/shared-types/src/lib/TpJobListing.ts
+++ b/libs/shared-types/src/lib/TpJobListing.ts
@@ -11,7 +11,6 @@ export type TpJobListing = {
   languageRequirements?: string
   desiredExperience?: string
   salaryRange?: string
-  isJobFair2022JobListing?: boolean
 
   tpCompanyProfileId?: string
   tpCompanyProfile?: TpCompanyProfile


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

## What should the reviewer know?

As per conversations in Slack, we want to drop the `isJobFair2022JobListing` property since it won't be part of the data migration to Salesforce, and it's deprecated anyways.