### PR TITLE
refactor(tp): drop non-used field

### DIFF
--- a/apps/admin-panel/src/App.jsx
+++ b/apps/admin-panel/src/App.jsx
@@ -1862,7 +1862,6 @@ const TpCompanyProfileShow = (props) => (
               />
               <TextField source="employmentType" />
               <TextField source="languageRequirements" />
-              <TextField source="desiredExperience" />
               <TextField source="salaryRange" />
               <ShowButton />
               <EditButton />
@@ -1942,7 +1941,6 @@ const TpCompanyProfileEdit = (props) => (
             />
             <TextField source="employmentType" />
             <TextField source="languageRequirements" />
-            <TextField source="desiredExperience" />
             <TextField source="salaryRange" />
             <ShowButton />
             <EditButton />
@@ -2000,7 +1998,6 @@ function tpJobListingListExporter(jobListings, fetchRelatedRecords) {
       tpCompanyProfile: { companyName },
       employmentType,
       languageRequirements,
-      desiredExperience,
       salaryRange,
     } = job
 
@@ -2010,7 +2007,6 @@ function tpJobListingListExporter(jobListings, fetchRelatedRecords) {
       companyName,
       employmentType,
       languageRequirements,
-      desiredExperience,
       salaryRange,
     }
   })
@@ -2056,7 +2052,6 @@ const TpJobListingShow = (props) => (
       />
       <TextField source="employmentType" />
       <TextField source="languageRequirements" />
-      <TextField source="desiredExperience" />
       <TextField source="salaryRange" />
     </SimpleShowLayout>
   </Show>
@@ -2086,7 +2081,6 @@ const TpJobListingEdit = (props) => (
       />
       <TextInput source="employmentType" />
       <TextInput source="languageRequirements" />
-      <TextInput source="desiredExperience" />
       <TextInput source="salaryRange" />
     </SimpleForm>
   </Edit>

--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
@@ -359,7 +359,6 @@ function buildBlankJobListing(
     idealTechnicalSkills: [],
     employmentType: '',
     languageRequirements: '',
-    desiredExperience: '',
     salaryRange: '',
     tpCompanyProfileId,
   }

--- a/libs/shared-types/src/lib/TpJobListing.ts
+++ b/libs/shared-types/src/lib/TpJobListing.ts
@@ -9,7 +9,6 @@ export type TpJobListing = {
   relatesToPositions?: string[]
   employmentType?: string
   languageRequirements?: string
-  desiredExperience?: string
   salaryRange?: string
 
   tpCompanyProfileId?: string


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

## What should the reviewer know?

This field doesn't serve any purpose. I've checked and double-checked the database, no job listing has any non-empty value for the `desiredExperience` field. And it's not a field we give users in the `<EditableJobPostings />`.

Hence, dropping ahead of the Salesforce migration.