### PR TITLE
Add isRemotePossible for TpJobListings

### DIFF
--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
@@ -263,6 +263,13 @@ function ModalForm({
           items={federalStatesOptions}
           {...formik}
         />
+        <Checkbox.Form
+          name="isRemotePossible"
+          checked={formik.values?.isRemotePossible}
+          {...formik}
+        >
+          Remote working is possible for this job listing
+        </Checkbox.Form>
         <FormTextArea
           label="Job Summary*"
           name={`summary`}

--- a/apps/redi-talent-pool/src/pages/app/browse/Browse.scss
+++ b/apps/redi-talent-pool/src/pages/app/browse/Browse.scss
@@ -90,7 +90,7 @@
   }
 }
 
-.filter-favourites {
+@mixin filter-box {
   display: flex;
   height: $control-height;
   border: 1px solid $input-border-color;
@@ -103,9 +103,30 @@
   &:hover {
     border-color: $input-hover-border-color;
   }
+}
+
+.filter-favourites {
+  @include filter-box;
 
   &__icon {
     font-size: 1.2rem;
+    path {
+      fill: $redi-orange-dark;
+    }
+  }
+
+  &--active {
+    background-color: $input-hover-border-color;
+    color: white;
+  }
+}
+
+.filter-remote {
+  @include filter-box;
+
+  & svg {
+    font-size: 1.2rem;
+    margin-right: 0.5em;
     path {
       fill: $redi-orange-dark;
     }

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
@@ -31,6 +31,7 @@ import { LoggedIn } from '../../../components/templates'
 import { JobListingCard } from '../../../components/organisms/JobListingCard'
 import { useTpjobseekerprofileUpdateMutation } from '../../../react-query/use-tpjobseekerprofile-mutation'
 import { objectEntries } from '@talent-connect/typescript-utilities'
+import { Home, HomeOutlined } from '@material-ui/icons'
 
 export function BrowseJobseeker() {
   const [companyName, setCompanyName] = useState('')
@@ -42,6 +43,7 @@ export function BrowseJobseeker() {
     employmentType: withDefault(ArrayParam, []),
     federalStates: withDefault(ArrayParam, []),
     onlyFavorites: withDefault(BooleanParam, undefined),
+    isRemotePossible: withDefault(BooleanParam, undefined),
   })
   const {
     relatedPositions,
@@ -49,6 +51,7 @@ export function BrowseJobseeker() {
     employmentType,
     federalStates,
     onlyFavorites,
+    isRemotePossible,
   } = query
 
   const history = useHistory()
@@ -61,6 +64,7 @@ export function BrowseJobseeker() {
     idealTechnicalSkills,
     employmentType,
     federalStates,
+    isRemotePossible,
   })
 
   const handleFavoriteJobListing = (value) => {
@@ -77,6 +81,13 @@ export function BrowseJobseeker() {
     setQuery((latestQuery) => ({
       ...latestQuery,
       onlyFavorites: onlyFavorites ? undefined : true,
+    }))
+  }
+
+  const toggleRemoteAvailableFilter = () => {
+    setQuery((latestQuery) => ({
+      ...latestQuery,
+      isRemotePossible: isRemotePossible ? undefined : true,
     }))
   }
 
@@ -180,6 +191,15 @@ export function BrowseJobseeker() {
               toggleFilters(federalStates, 'federalStates', item)
             }
           />
+        </div>
+      </div>
+      <div className="filters">
+        <div
+          className="filters-inner filter-remote"
+          onClick={toggleRemoteAvailableFilter}
+        >
+          {isRemotePossible ? <Home /> : <HomeOutlined />}
+          Remote Working Possible
         </div>
       </div>
       <div className="active-filters">

--- a/apps/redi-talent-pool/src/pages/app/job-listing/JobListing.tsx
+++ b/apps/redi-talent-pool/src/pages/app/job-listing/JobListing.tsx
@@ -52,17 +52,25 @@ export function JobListing() {
           <div
             style={{
               display: 'flex',
-              flexDirection: 'row',
-              alignItems: 'center',
+              flexDirection: 'column',
+              justifyContent: 'center',
             }}
           >
             {jobListing?.location ? (
-              <>
+              <div style={{ display: 'flex', marginBottom: '4px' }}>
                 <Icon icon="mapPin" />{' '}
                 <Content>
                   <strong>{jobListing?.location}</strong>
                 </Content>
-              </>
+              </div>
+            ) : null}
+            {jobListing?.isRemotePossible ? (
+              <div style={{ display: 'flex' }}>
+                <Icon icon="mapPin" />{' '}
+                <Content>
+                  <strong>Remote working possible</strong>
+                </Content>
+              </div>
             ) : null}
           </div>
         </div>

--- a/apps/redi-talent-pool/src/services/api/api.tsx
+++ b/apps/redi-talent-pool/src/services/api/api.tsx
@@ -276,6 +276,7 @@ export interface TpJobListingFilters {
   idealTechnicalSkills: string[]
   employmentType: string[]
   federalStates: string[]
+  isRemotePossible: boolean
 }
 
 export async function fetchAllTpJobListingsUsingFilters({
@@ -283,6 +284,7 @@ export async function fetchAllTpJobListingsUsingFilters({
   idealTechnicalSkills,
   employmentType,
   federalStates,
+  isRemotePossible,
 }: TpJobListingFilters): Promise<Array<TpJobListing>> {
   const filterRelatedPositions =
     relatedPositions && relatedPositions.length !== 0
@@ -315,6 +317,7 @@ export async function fetchAllTpJobListingsUsingFilters({
             idealTechnicalSkills: filterIdealTechnicalSkills,
             employmentType: filterDesiredEmploymentTypeOptions,
             federalState: filterFederalStates,
+            isRemotePossible,
           },
         ],
       },

--- a/libs/shared-types/src/lib/TpJobListing.ts
+++ b/libs/shared-types/src/lib/TpJobListing.ts
@@ -10,6 +10,7 @@ export type TpJobListing = {
   employmentType?: string
   languageRequirements?: string
   salaryRange?: string
+  isRemotePossible?: boolean
 
   tpCompanyProfileId?: string
   tpCompanyProfile?: TpCompanyProfile

--- a/libs/talent-pool/config/src/lib/talent-pool-config.ts
+++ b/libs/talent-pool/config/src/lib/talent-pool-config.ts
@@ -760,7 +760,8 @@ export const germanFederalStates = {
   'rheinland-pfalz': 'Rheinland-Pfalz',
   saarland: 'Saarland',
   sachsen: 'Sachsen',
-  sachsenAnhalt: 'Sachsen-Anhalt',
-  schleswigHolstein: 'Schleswig-Holstein',
+  'sachsen-anhalt': 'Sachsen-Anhalt',
+  'schleswig-holstein': 'Schleswig-Holstein',
   thueringen: 'Thüringen',
+  'outside-germany': 'Outside Germany',
 } as const


### PR DESCRIPTION
## Description
This PR adds a new field for TpJobListing entity, `isRemotePossible`. Using this field
* companies can mark the job listings they open as Remote Possible 
* This information will be shown in a Job Listing page as in the screenshots below
* Jobseekers can filter job openings using a new filter regarding this information

## Screenshots
![CleanShot 2022-04-19 at 00 48 17](https://user-images.githubusercontent.com/6314657/163889388-997c7ac6-ef42-4c3c-99af-3fd2b63c16ed.png)

![CleanShot 2022-04-19 at 00 45 52](https://user-images.githubusercontent.com/6314657/163889235-ee66aba9-0a24-498d-b12f-6ef34c48ea74.png)

![CleanShot 2022-04-19 at 00 47 01](https://user-images.githubusercontent.com/6314657/163889259-7387a07b-c29e-4c10-a127-074b49cd89fc.png)

![CleanShot 2022-04-19 at 00 47 23](https://user-images.githubusercontent.com/6314657/163889302-78745e02-9ea9-4b0b-bcd4-e075abbd58af.png)
