### PR TITLE
Add isHired field and Tag for TpJobseekers

### DIFF
--- a/apps/admin-panel/src/App.jsx
+++ b/apps/admin-panel/src/App.jsx
@@ -1342,7 +1342,6 @@ const TpJobseekerProfileListFilters = (props) => (
         name: val,
       }))}
     />
-    <NullableBooleanInput source="isJobFair2022Participant" />
   </Filter>
 )
 
@@ -1418,10 +1417,7 @@ const TpJobseekerProfileShow = (props) => (
         <Tab label="Profile">
           <TextField source="state" />
           <BooleanField source="isProfileVisibleToCompanies" />
-          <BooleanField
-            initialValue={false}
-            source="isJobFair2022Participant"
-          />
+          <BooleanField initialValue={false} source="isHired" />
           <Avatar />
           <TextField source="firstName" />
           <TextField source="lastName" />
@@ -1575,7 +1571,7 @@ const TpJobseekerProfileEdit = (props) => (
       <FormTab label="Profile">
         <TextField source="state" />
         <BooleanInput source="isProfileVisibleToCompanies" />
-        <BooleanInput initialValue={false} source="isJobFair2022Participant" />
+        <BooleanInput initialValue={false} source="isHired" />
         {/* <Avatar /> */}
         <TextInput source="firstName" />
         <TextInput source="lastName" />

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.scss
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.scss
@@ -25,6 +25,15 @@
     color: $grey;
   }
 
+  &__hired-tag {
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    border-radius: 0 !important;
+    border-bottom-right-radius: 4px !important;
+  }
+
   &__image {
     img {
       height: 9.5rem;

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
@@ -7,10 +7,9 @@ import {
 } from '@talent-connect/talent-pool/config'
 import classnames from 'clsx'
 import React from 'react'
-import { Card, Element } from 'react-bulma-components'
+import { Card, Element, Tag } from 'react-bulma-components'
 import './JobseekerProfileCard.scss'
 import placeholderImage from '../../assets/img-placeholder.png'
-
 interface JobseekerProfileCardProps {
   jobseekerProfile: Partial<TpJobseekerProfile>
   onClick?: () => void
@@ -56,6 +55,9 @@ export function JobseekerProfileCard({
         alt={fullName}
       />
       <Card.Content>
+        {jobseekerProfile.isHired ? (
+          <Tag className="jobseeker-profile-card__hired-tag">HIRED!</Tag>
+        ) : null}
         {toggleFavorite && (
           <div
             className="jobseeker-profile-card__favorite"

--- a/libs/shared-types/src/lib/TpJobseekerProfile.ts
+++ b/libs/shared-types/src/lib/TpJobseekerProfile.ts
@@ -53,6 +53,7 @@ export type TpJobseekerProfile = {
   isJobFair2022Participant?: boolean
 
   isProfileVisibleToCompanies: boolean
+  isHired: boolean
 
   favouritedTpJobListingIds: string[]
 }


### PR DESCRIPTION
## Description
This PR adds a new field `isHired` for TpJobseeker entity. This field is meant to be used for promoting our hired jobseekers in the Browse section for companies. Until now, the solution for this was updating these people's names with JUST HIRED or HIRED, however this would cause us some headache over the Salesforce migration, hence this result.

This field will be only toggled through the Admin Panel (and Salesforce Panel after the migration). Jobseekers won't be able to mark themselves as Hired. (yet? Maybe we can also discuss this as a feature to implement)

You can see the screenshots of the simple design I came up with. @miriam-aha Please let me know if we should come up with a better design for this.

PS: I added the toggle by replacing `isJobFair2022Participant` with `isHired` in the Admin Panel, since it was an outdated toggle.

## Screenshots
### Admin Panel - Toggling a Jobseeker as Hired:
![CleanShot 2022-04-25 at 08 29 27](https://user-images.githubusercontent.com/6314657/165032551-c05cdd19-3c6f-4dd5-ba0d-73b427cb3de7.png)

### How the Hired badge looks like in Company - Browse:
![CleanShot 2022-04-25 at 08 31 21](https://user-images.githubusercontent.com/6314657/165032764-0ff75814-afbe-4939-8941-694594a74593.png)

