### PR TITLE
Avoid creating ToJobseekerProfile for Con Users with Company Profile

### DIFF
--- a/apps/api/common/models/red-user.js
+++ b/apps/api/common/models/red-user.js
@@ -184,15 +184,12 @@ module.exports = function (RedUser) {
     const redUserInst = await loginHook_getRedUser(context)
     const redUser = redUserInst.toJSON()
 
-    const userAlreadyHasTalentPoolJobseekerProfile = Boolean(
-      redUser.tpJobseekerProfile
+    const userAlreadyHasTalentPoolProfile = Boolean(
+      redUser.tpJobseekerProfile || redUser.tpCompanyProfile
     )
     const userDoesNotHaveConnectProfile = !redUser.redProfile
 
-    if (
-      userAlreadyHasTalentPoolJobseekerProfile ||
-      userDoesNotHaveConnectProfile
-    ) {
+    if (userAlreadyHasTalentPoolProfile || userDoesNotHaveConnectProfile) {
       return next()
     }
 
@@ -208,7 +205,7 @@ module.exports = function (RedUser) {
   async function loginHook_getRedUser(context) {
     const redUserId = context.result.toJSON().userId.toString()
     const redUserInst = await RedUser.findById(redUserId, {
-      include: ['redProfile', 'tpJobseekerProfile'],
+      include: ['redProfile', 'tpJobseekerProfile', 'tpCompanyProfile'],
     })
 
     return redUserInst
@@ -236,7 +233,8 @@ module.exports = function (RedUser) {
       firstName: tpJobseekerProfile.firstName,
       lastName: tpJobseekerProfile.lastName,
       contactEmail: tpJobseekerProfile.contactEmail,
-      mentee_currentlyEnrolledInCourse: tpJobseekerProfile.currentlyEnrolledInCourse,
+      mentee_currentlyEnrolledInCourse:
+        tpJobseekerProfile.currentlyEnrolledInCourse,
       userType: 'public-sign-up-mentee-pending-review',
       gaveGdprConsentAt: tpJobseekerProfile.gaveGdprConsentAt,
       signupSource: 'existing-user-with-tp-profile-logging-into-con',


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
No Issue

## What should the reviewer know?
This PR attempts to fix a nasty edge-case we have when logging in to Talent Pool. TP Login logic works as following:

```
Login Attempt in Talent Pool
  User has Jobseeker Profile? => Continue Login
  User has NO Connect Profile? => Continue Login
  Otherwise => Create a Jobseeker Profile using the existing Con Profile and login to that 
```

This logic works perfectly to reuse the same Red User and Login Credentials for existing Mentors or Mentees, when they want to login as a Jobseeker. However, it fails for a very edge case, which a Mentor or Mentee wants to login as a Company Representative. The system basically decides to create a Jobseeker profile for everyone in that case.

To prevent this from happening, I'm slightly changing the logic above, into this:

```
Login Attempt in Talent Pool
  User has Talent Pool (either Jobseeker or Company) Profile? => Continue Login
  User has NO Connect Profile? => Continue Login
  Otherwise => Create a Jobseeker Profile using the existing Con Profile and login to that 
``` 