### PR TITLE
[Issue #534] Show Full Face of Talent Pool Jobseekers 

### DIFF
--- a/apps/redi-talent-pool/src/components/organisms/Avatar.scss
+++ b/apps/redi-talent-pool/src/components/organisms/Avatar.scss
@@ -124,3 +124,7 @@
     z-index: 5;
   }
 }
+
+.reactEasyCrop_Container {
+  top: 73px;
+}

--- a/apps/redi-talent-pool/src/components/organisms/Avatar.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/Avatar.tsx
@@ -204,7 +204,7 @@ const AvatarEditable = ({
           <Cropper
             image={imageSrc}
             crop={crop}
-            aspect={2 / 1}
+            aspect={1 / 1}
             style={{ containerStyle: { top: 73 } }}
             zoom={zoom}
             showGrid={false}

--- a/apps/redi-talent-pool/src/components/organisms/Avatar.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/Avatar.tsx
@@ -1,16 +1,22 @@
+import { useCallback, useState } from 'react'
+import { FormikValues, useFormik } from 'formik'
+import classnames from 'classnames'
+import * as Yup from 'yup'
+import Cropper from 'react-easy-crop'
+import ReactS3Uploader from 'react-s3-uploader'
+import { Element } from 'react-bulma-components'
+
+import { Button, Modal } from '@talent-connect/shared-atomic-design-components'
 import {
   AWS_PROFILE_AVATARS_BUCKET_BASE_URL,
   S3_UPLOAD_SIGN_URL,
 } from '@talent-connect/shared-config'
 import {
-  TpJobseekerProfile,
   TpCompanyProfile,
+  TpJobseekerProfile,
 } from '@talent-connect/shared-types'
-import classnames from 'classnames'
-import { FormikValues, useFormik } from 'formik'
-import { Element } from 'react-bulma-components'
-import ReactS3Uploader from 'react-s3-uploader'
-import * as Yup from 'yup'
+import { getCroppedImg } from '@talent-connect/shared-utils'
+
 import placeholderImage from '../../assets/img-placeholder.png'
 import { ReactComponent as UploadImage } from '../../assets/uploadImage.svg'
 import './Avatar.scss'
@@ -55,11 +61,32 @@ const Avatar = ({ profile }: AvatarProps) => {
   )
 }
 
+function readFile(file) {
+  return new Promise((resolve) => {
+    const reader = new FileReader()
+    reader.addEventListener('load', () => resolve(reader.result), false)
+    reader.readAsDataURL(file)
+  })
+}
+
 const AvatarEditable = ({
   profile,
   profileSaveStart,
   callToActionText = 'Add your picture',
 }: AvatarEditable) => {
+  const [showCropperModal, setShowCropperModal] = useState(false)
+  const [imageSrc, setImageSrc] = useState(null)
+  const [imageFileName, setImageFileName] = useState('')
+
+  const [crop, setCrop] = useState({ x: 0, y: 0 })
+  const [zoom, setZoom] = useState(1)
+
+  // This is how to keep functions in React state: https://stackoverflow.com/questions/55621212/is-it-possible-to-react-usestate-in-react
+  const [nextFn, setNextFn] = useState(() => (croppedImgFile) => {
+    return
+  })
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState(null)
+
   const { profileAvatarImageS3Key } = profile
   const imgURL = AWS_PROFILE_AVATARS_BUCKET_BASE_URL + profileAvatarImageS3Key
 
@@ -78,9 +105,41 @@ const AvatarEditable = ({
     onSubmit: submitForm,
   })
 
-  const onUploadSuccess = (result: any) => {
+  const onCropComplete = useCallback((croppedArea, croppedAreaPixels) => {
+    setCroppedAreaPixels(croppedAreaPixels)
+  }, [])
+
+  const onUploadStart = async (file, next) => {
+    const imageDataUrl = await readFile(file)
+
+    setImageSrc(imageDataUrl)
+    setImageFileName(file.name)
+
+    // Storing next function passed by react-s3-uploader to be called in another function (onSaveClick)
+    setNextFn(() => (croppedImgFile) => next(croppedImgFile))
+
+    setShowCropperModal(true)
+  }
+
+  const onSaveClick = useCallback(async () => {
+    try {
+      const croppedImage = (await getCroppedImg(
+        imageSrc,
+        croppedAreaPixels
+      )) as BlobPart
+      const croppedImgFile = new File([croppedImage], imageFileName)
+
+      nextFn(croppedImgFile)
+    } catch (e) {
+      console.error(e)
+    }
+  }, [imageSrc, imageFileName, croppedAreaPixels, nextFn])
+
+  const onUploadFinish = (result: any) => {
     formik.setFieldValue('profileAvatarImageS3Key', result.fileKey)
     formik.handleSubmit()
+
+    setShowCropperModal(false)
   }
 
   return (
@@ -127,11 +186,37 @@ const AvatarEditable = ({
         signingUrl={S3_UPLOAD_SIGN_URL}
         accept="image/*"
         uploadRequestHeaders={{ 'x-amz-acl': 'public-read' }}
-        onSignedUrl={(c: any) => console.log(c)}
         onError={(c: any) => console.log(c)}
-        onFinish={onUploadSuccess}
+        preprocess={onUploadStart}
+        onFinish={onUploadFinish}
         contentDisposition="auto"
       />
+
+      <Modal
+        styles={{
+          height: 600,
+        }}
+        show={showCropperModal && imageSrc}
+        stateFn={setShowCropperModal}
+        title="Crop your profile picture"
+      >
+        <Modal.Body>
+          <Cropper
+            image={imageSrc}
+            crop={crop}
+            aspect={2 / 1}
+            style={{ containerStyle: { top: 73 } }}
+            zoom={zoom}
+            showGrid={false}
+            onCropChange={setCrop}
+            onCropComplete={onCropComplete}
+            onZoomChange={setZoom}
+          />
+        </Modal.Body>
+        <Modal.Foot>
+          <Button onClick={onSaveClick}>Save</Button>
+        </Modal.Foot>
+      </Modal>
     </div>
   )
 }

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.scss
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.scss
@@ -35,10 +35,20 @@
   }
 
   &__image {
+    .image {
+      display: flex;
+      justify-content: center;
+    }
+
     img {
+      width: 9.5rem;
       height: 9.5rem;
       overflow: hidden;
       object-fit: contain;
+
+      border: 2px solid $redi-orange-dark;
+      border-radius: 50%;
+      box-shadow: 2px 0 15px 0 rgba(255, 92, 31, 0.34);
     }
   }
 

--- a/libs/shared-utils/src/index.ts
+++ b/libs/shared-utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/assert-unreachable'
 export * from './lib/calculate-age'
+export * from './lib/crop-image'

--- a/libs/shared-utils/src/lib/crop-image.ts
+++ b/libs/shared-utils/src/lib/crop-image.ts
@@ -1,0 +1,92 @@
+export const createImage = (url) =>
+  new Promise((resolve, reject) => {
+    const image = new Image()
+    image.addEventListener('load', () => resolve(image))
+    image.addEventListener('error', (error) => reject(error))
+    image.setAttribute('crossOrigin', 'anonymous') // needed to avoid cross-origin issues on CodeSandbox
+    image.src = url
+  })
+
+export function getRadianAngle(degreeValue) {
+  return (degreeValue * Math.PI) / 180
+}
+
+/**
+ * Returns the new bounding area of a rotated rectangle.
+ */
+export function rotateSize(width, height, rotation) {
+  const rotRad = getRadianAngle(rotation)
+
+  return {
+    width:
+      Math.abs(Math.cos(rotRad) * width) + Math.abs(Math.sin(rotRad) * height),
+    height:
+      Math.abs(Math.sin(rotRad) * width) + Math.abs(Math.cos(rotRad) * height),
+  }
+}
+
+/**
+ * This function was adapted from the one in the ReadMe of https://github.com/DominicTobias/react-image-crop
+ */
+export async function getCroppedImg(
+  imageSrc,
+  pixelCrop,
+  rotation = 0,
+  flip = { horizontal: false, vertical: false }
+) {
+  const image = (await createImage(imageSrc)) as HTMLImageElement
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+
+  if (!ctx) {
+    return null
+  }
+
+  const rotRad = getRadianAngle(rotation)
+
+  // calculate bounding box of the rotated image
+  const { width: bBoxWidth, height: bBoxHeight } = rotateSize(
+    image.width,
+    image.height,
+    rotation
+  )
+
+  // set canvas size to match the bounding box
+  canvas.width = bBoxWidth
+  canvas.height = bBoxHeight
+
+  // translate canvas context to a central location to allow rotating and flipping around the center
+  ctx.translate(bBoxWidth / 2, bBoxHeight / 2)
+  ctx.rotate(rotRad)
+  ctx.scale(flip.horizontal ? -1 : 1, flip.vertical ? -1 : 1)
+  ctx.translate(-image.width / 2, -image.height / 2)
+
+  // draw rotated image
+  ctx.drawImage(image, 0, 0)
+
+  // croppedAreaPixels values are bounding box relative
+  // extract the cropped image using these values
+  const data = ctx.getImageData(
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height
+  )
+
+  // set canvas width to final desired crop size - this will clear existing context
+  canvas.width = pixelCrop.width
+  canvas.height = pixelCrop.height
+
+  // paste generated rotate image at the top left corner
+  ctx.putImageData(data, 0, 0)
+
+  // As Base64 string
+  // return canvas.toDataURL('image/jpeg');
+
+  // As a blob
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((file) => {
+      resolve(file)
+    }, 'image/jpeg')
+  })
+}

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "react-bulma-components": "^3.2.0",
     "react-datepicker": "^3.8.0",
     "react-dom": "17.0.2",
+    "react-easy-crop": "^4.2.0",
     "react-final-form": "^6.3.0",
     "react-i18next": "^11.4.0",
     "react-markdown": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13723,6 +13723,11 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+normalize-wheel@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-wheel/-/normalize-wheel-1.0.1.tgz#aec886affdb045070d856447df62ecf86146ec45"
+  integrity sha1-rsiGr/2wRQcNhWRH32Ls+GFG7EU=
+
 npm-bundled@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.2.tgz#944c78789bd739035b70baa2ca5cc32b8d860bc1"
@@ -15712,6 +15717,14 @@ react-dropzone@~4.0.1:
   dependencies:
     attr-accept "^1.0.3"
     prop-types "^15.5.7"
+
+react-easy-crop@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-easy-crop/-/react-easy-crop-4.2.0.tgz#f856e972f73f6ff320c2144c7db3af7cfb6022ea"
+  integrity sha512-NJdeG6JPlOvXPNcQlmyEyjuseTiZVDa0M5X6BwTxSPR30MG3ROsSHKeGl5SQdI3TfmsoEgvl7MbM+AjFGj+faw==
+  dependencies:
+    normalize-wheel "^1.0.1"
+    tslib "2.0.1"
 
 react-element-to-jsx-string@^14.3.2:
   version "14.3.2"
@@ -18614,6 +18627,11 @@ tsconfig-paths@^3.4.0, tsconfig-paths@^3.9.0:
     json5 "^2.2.0"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
+
+tslib@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
 tslib@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#534 

## What should the reviewer know?
This PR adds an image crop feature when TP Jobseekers upload their profile pictures. This will allow them to better position their face on the Jobseeker Cards.

![CleanShot 2022-05-23 at 07 37 03](https://user-images.githubusercontent.com/6314657/169750589-d6a0a8f8-e747-4ceb-8393-a1a96078d71f.gif)

To go along with this feature (and the new aspect ratio of the jobseeker profile pictures) this PR also makes the Jobseeker Profile Card images round (and more similar to how it looks in the profile)

![CleanShot 2022-05-23 at 07 52 42](https://user-images.githubusercontent.com/6314657/169752325-e8bc2551-4d06-4ada-b353-1ef74429cb75.png)
