### PR TITLE
[Issue 534] Add image cropping & square logos for Companies

### DIFF
--- a/apps/redi-talent-pool/src/components/organisms/Avatar.scss
+++ b/apps/redi-talent-pool/src/components/organisms/Avatar.scss
@@ -60,6 +60,14 @@
     }
   }
 
+  &--square {
+    border-radius: 10px;
+  }
+
+  &--square::before {
+    border-radius: 0;
+  }
+
   &--placeholder:before {
     border: 1px solid #a0a0a0;
     background-color: $grey-extra-light;
@@ -74,6 +82,10 @@
     height: 100%;
     object-fit: cover;
     z-index: 1;
+  }
+
+  &__image--square {
+    border-radius: 0;
   }
 
   &__button {

--- a/apps/redi-talent-pool/src/components/organisms/Avatar.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/Avatar.tsx
@@ -23,6 +23,7 @@ import './Avatar.scss'
 
 interface AvatarProps {
   profile: Partial<TpJobseekerProfile> | Partial<TpCompanyProfile>
+  shape?: 'circle' | 'square'
 }
 interface AvatarEditable {
   profile: Partial<TpJobseekerProfile> | Partial<TpCompanyProfile>
@@ -30,6 +31,7 @@ interface AvatarEditable {
     profile: Partial<TpJobseekerProfile> | Partial<TpCompanyProfile>
   ) => void
   callToActionText?: string
+  shape?: 'circle' | 'square'
 }
 
 interface AvatarFormValues {
@@ -40,7 +42,7 @@ const validationSchema = Yup.object({
   profileAvatarImageS3Key: Yup.string().max(255),
 })
 
-const Avatar = ({ profile }: AvatarProps) => {
+const Avatar = ({ profile, shape = 'circle' }: AvatarProps) => {
   const { profileAvatarImageS3Key } = profile
   const imgSrc = profileAvatarImageS3Key
     ? AWS_PROFILE_AVATARS_BUCKET_BASE_URL + profileAvatarImageS3Key
@@ -50,12 +52,15 @@ const Avatar = ({ profile }: AvatarProps) => {
     <div
       className={classnames('avatar', {
         'avatar--placeholder': !profileAvatarImageS3Key,
+        'avatar--square': shape === 'square',
       })}
     >
       <img
         src={imgSrc}
         alt={`${profile.firstName} ${profile.lastName}`}
-        className="avatar__image"
+        className={classnames('avatar__image', {
+          'avatar__image--square': shape === 'square',
+        })}
       />
     </div>
   )
@@ -73,6 +78,7 @@ const AvatarEditable = ({
   profile,
   profileSaveStart,
   callToActionText = 'Add your picture',
+  shape = 'circle',
 }: AvatarEditable) => {
   const [showCropperModal, setShowCropperModal] = useState(false)
   const [imageSrc, setImageSrc] = useState(null)
@@ -146,6 +152,7 @@ const AvatarEditable = ({
     <div
       className={classnames('avatar avatar--editable', {
         'avatar--placeholder': !profileAvatarImageS3Key,
+        'avatar--square': shape === 'square',
       })}
     >
       {profileAvatarImageS3Key && (
@@ -153,7 +160,9 @@ const AvatarEditable = ({
           <img
             src={imgURL}
             alt={`${profile.firstName} ${profile.lastName}`}
-            className="avatar__image"
+            className={classnames('avatar__image', {
+              'avatar__image--square': shape === 'square',
+            })}
           />
           <Element
             renderAs="span"
@@ -205,7 +214,6 @@ const AvatarEditable = ({
             image={imageSrc}
             crop={crop}
             aspect={1 / 1}
-            style={{ containerStyle: { top: 73 } }}
             zoom={zoom}
             showGrid={false}
             onCropChange={setCrop}

--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableNamePhotoLocation.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableNamePhotoLocation.tsx
@@ -42,6 +42,7 @@ export function EditableNamePhotoLocation({ profile, disableEditing }: Props) {
                 profile={profile}
                 profileSaveStart={mutation.mutate}
                 callToActionText="Please add your company logo"
+                shape="square"
               />
             ) : null}
           </Columns.Column>

--- a/apps/redi-talent-pool/src/pages/app/job-listing/JobListing.tsx
+++ b/apps/redi-talent-pool/src/pages/app/job-listing/JobListing.tsx
@@ -27,7 +27,9 @@ export function JobListing() {
     <LoggedIn>
       <div style={{ display: 'flex' }}>
         <div style={{ width: '15rem' }}>
-          {jobListing ? <Avatar profile={jobListing.tpCompanyProfile} /> : null}
+          {jobListing ? (
+            <Avatar profile={jobListing.tpCompanyProfile} shape="square" />
+          ) : null}
         </div>
         <div
           style={{

--- a/libs/shared-atomic-design-components/src/lib/molecules/Modal.scss
+++ b/libs/shared-atomic-design-components/src/lib/molecules/Modal.scss
@@ -27,6 +27,7 @@
   }
 
   &__heading {
+    z-index: 1;
     .title {
       font-size: 1.5rem !important;
       margin-right: 2rem;

--- a/libs/shared-utils/src/lib/crop-image.ts
+++ b/libs/shared-utils/src/lib/crop-image.ts
@@ -87,6 +87,6 @@ export async function getCroppedImg(
   return new Promise((resolve, reject) => {
     canvas.toBlob((file) => {
       resolve(file)
-    }, 'image/jpeg')
+    }, 'image/png')
   })
 }


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#534 

## What should the reviewer know?
This PR adds support for Logo cropping for TP Companies. To support this feature better, I'm introducing also square logos for companies, which can be seen in the screenshots below:

### When no logo added:
![CleanShot 2022-06-11 at 19 47 01](https://user-images.githubusercontent.com/6314657/173199087-5cc7c37b-2001-4347-82c5-52cf497e9c42.png)

### Editable Profile page when logo added:
![CleanShot 2022-06-11 at 19 48 31](https://user-images.githubusercontent.com/6314657/173199138-516d87b9-69de-4a43-976c-d8fb7a688bda.png)

### Cropping Popup:
![CleanShot 2022-06-11 at 19 49 44](https://user-images.githubusercontent.com/6314657/173199194-73d546d0-34ac-4762-9317-395e8821a470.gif)

### Joblisting Page:
![CleanShot 2022-06-11 at 19 51 02](https://user-images.githubusercontent.com/6314657/173199203-be75bbef-987a-482f-802b-3858a1d9fcc2.png)

