### PR TITLE
Fix broken one-way sync

### DIFF
--- a/.github/workflows/mirror-to-private-repo.yml
+++ b/.github/workflows/mirror-to-private-repo.yml
@@ -6,11 +6,12 @@ jobs:
   to_mirror_repo:
     runs-on: ubuntu-latest
     steps: # <-- must use actions/checkout before mirroring!
-      - uses: actions/checkout@v2
+      - name: repo-sync
+        uses: wei/git-sync@v3
         with:
-          fetch-depth: 0
-      - uses: pixta-dev/repository-mirroring-action@v1
-        with:
-          target_repo_url: ${{ secrets.SYNC_REPOSITORY_TARGET_URL }}
-          ssh_private_key: # <-- use 'secrets' to pass credential information.
-            ${{ secrets.SYNC_REPOSITORY_DEPLOY_TOKEN }}
+          source_repo: 'talent-connect/connect'
+          destination_repo: 'talent-connect/connnect-ffg-private'
+          source_branch: 'refs/remotes/source/*'
+          destination_branch: 'refs/heads/*'
+          destination_ssh_private_key: ${{ secrets.SYNC_REPOSITORY_DEPLOY_TOKEN }}
+          # ${{ secrets.SYNC_REPOSITORY_TARGET_URL }}

--- a/.github/workflows/mirror-to-private-repo.yml
+++ b/.github/workflows/mirror-to-private-repo.yml
@@ -14,4 +14,3 @@ jobs:
           source_branch: 'refs/remotes/source/*'
           destination_branch: 'refs/heads/*'
           destination_ssh_private_key: ${{ secrets.SYNC_REPOSITORY_DEPLOY_TOKEN }}
-          # ${{ secrets.SYNC_REPOSITORY_TARGET_URL }}


### PR DESCRIPTION
@helloanil, I'm replacing one plugin with another, for the one-way sync mechanism. Turns out the former one was **deleting** branches on the ffg repo that they'd created 😆 Not what we want