### PR TITLE
ReDI Job Fair 2023 Toggle

### DIFF
--- a/apps/admin-panel/src/App.jsx
+++ b/apps/admin-panel/src/App.jsx
@@ -1416,6 +1416,7 @@ const TpJobseekerProfileShow = (props) => (
       <TabbedShowLayout>
         <Tab label="Profile">
           <TextField source="state" />
+          <BooleanField source="isJobFair2023Participant" />
           <BooleanField source="isProfileVisibleToCompanies" />
           <BooleanField initialValue={false} source="isHired" />
           <Avatar />

--- a/apps/redi-connect/src/config/config.tsx
+++ b/apps/redi-connect/src/config/config.tsx
@@ -13,6 +13,8 @@ const rediLocation = process.env.NX_REDI_CONNECT_REDI_LOCATION as RediLocation
 const validRediLocations = Object.keys(rediLocationNames)
 
 if (!validRediLocations.includes(rediLocation))
-  throw new Error('Invalid RediLocation')
+  throw new Error(
+    `Invalid RediLocation: ${rediLocation}. Valid Locations: ${validRediLocations}`
+  )
 
 export const courses = allCourses.filter((c) => c.location === rediLocation)

--- a/apps/redi-talent-pool/src/pages/app/browse/Browse.scss
+++ b/apps/redi-talent-pool/src/pages/app/browse/Browse.scss
@@ -20,7 +20,7 @@
     }
   }
 
-  &__jobfair2022 {
+  &__jobfair {
     align-items: center;
   }
 }

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -49,7 +49,7 @@ export function BrowseCompany() {
     skills: withDefault(ArrayParam, []),
     federalStates: withDefault(ArrayParam, []),
     onlyFavorites: withDefault(BooleanParam, undefined),
-    isJobFair2022Participant: withDefault(BooleanParam, undefined),
+    isJobFair2023Participant: withDefault(BooleanParam, undefined),
   })
   const {
     name,
@@ -58,7 +58,7 @@ export function BrowseCompany() {
     skills,
     federalStates,
     onlyFavorites,
-    isJobFair2022Participant,
+    isJobFair2023Participant,
   } = query
 
   const history = useHistory()
@@ -69,7 +69,7 @@ export function BrowseCompany() {
     employmentTypes,
     skills,
     federalStates,
-    isJobFair2022Participant,
+    isJobFair2023Participant,
   })
   const { data: companyProfile } = useTpCompanyProfileQuery()
   const tpCompanyProfileUpdateMutation = useTpCompanyProfileUpdateMutation()
@@ -96,11 +96,11 @@ export function BrowseCompany() {
     setQuery((latestQuery) => ({ ...latestQuery, [filterName]: newFilters }))
   }
 
-  const toggleJobFair2022Filter = () =>
+  const toggleJobFair2023Filter = () =>
     setQuery((latestQuery) => ({
       ...latestQuery,
-      isJobFair2022Participant:
-        isJobFair2022Participant === undefined ? true : undefined,
+      isJobFair2023Participant:
+        isJobFair2023Participant === undefined ? true : undefined,
     }))
 
   const setName = (value) => {
@@ -114,7 +114,7 @@ export function BrowseCompany() {
       desiredPositions: [],
       employmentTypes: [],
       federalStates: [],
-      isJobFair2022Participant: undefined,
+      isJobFair2023Participant: undefined,
     }))
   }
 
@@ -123,7 +123,7 @@ export function BrowseCompany() {
     desiredPositions.length !== 0 ||
     federalStates.length !== 0 ||
     employmentTypes.length !== 0 ||
-    isJobFair2022Participant
+    isJobFair2023Participant
 
   return (
     <LoggedIn>
@@ -209,13 +209,13 @@ export function BrowseCompany() {
         </div>
       </div>
       <div className="filters">
-        <div className="filters-inner filters__jobfair2022">
+        <div className="filters-inner filters__jobfair">
           <Checkbox
-            name="isJobFair2022Participant"
-            checked={isJobFair2022Participant || false}
-            handleChange={toggleJobFair2022Filter}
+            name="isJobFair2023Participant"
+            checked={isJobFair2023Participant || false}
+            handleChange={toggleJobFair2023Filter}
           >
-            Filter by ReDI Job Fair 2022
+            Attending ReDI Job Fair 2023
           </Checkbox>
         </div>
       </div>
@@ -260,12 +260,12 @@ export function BrowseCompany() {
                 }
               />
             ))}
-            {isJobFair2022Participant && (
+            {isJobFair2023Participant && (
               <FilterTag
                 key="redi-job-fair-2022-filter"
                 id="redi-job-fair-2022-filter"
-                label="ReDI Job Fair 2022"
-                onClickHandler={toggleJobFair2022Filter}
+                label="Attending ReDI Job Fair 2023"
+                onClickHandler={toggleJobFair2023Filter}
               />
             )}
             <span className="active-filters__clear-all" onClick={clearFilters}>

--- a/apps/redi-talent-pool/src/pages/app/me/MeJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/MeJobseeker.tsx
@@ -46,6 +46,12 @@ export function MeJobseeker() {
       isProfileVisibleToCompanies: !profile.isProfileVisibleToCompanies,
     })
 
+  const onJobFair2023ParticipateChange = () =>
+    mutation.mutate({
+      ...profile,
+      isJobFair2023Participant: !profile.isJobFair2023Participant,
+    })
+
   return (
     <LoggedIn>
       {profile?.state === 'profile-approved' ? (
@@ -71,6 +77,15 @@ export function MeJobseeker() {
             <OnboardingSteps />
           </div>
           <EditableNamePhotoLocation profile={profile} />
+          <div style={{ marginBottom: '1.5rem' }}>
+            <Checkbox
+              checked={profile.isJobFair2023Participant}
+              customOnChange={onJobFair2023ParticipateChange}
+            >
+              I will attend the <b>ReDI Job Fair</b> happening on{' '}
+              <b>15/02/2023</b>.
+            </Checkbox>
+          </div>
           <EditableOverview profile={profile} />
           <EditableSummary profile={profile} />
           <EditableProfessionalExperience profile={profile} />

--- a/apps/redi-talent-pool/src/services/api/api.tsx
+++ b/apps/redi-talent-pool/src/services/api/api.tsx
@@ -114,7 +114,7 @@ export interface TpJobseekerProfileFilters {
   employmentTypes: string[]
   skills: string[]
   federalStates: string[]
-  isJobFair2022Participant: boolean
+  isJobFair2023Participant: boolean
 }
 
 export async function fetchAllTpJobseekerProfiles({
@@ -123,7 +123,7 @@ export async function fetchAllTpJobseekerProfiles({
   employmentTypes,
   skills: topSkills,
   federalStates,
-  isJobFair2022Participant,
+  isJobFair2023Participant,
 }: TpJobseekerProfileFilters): Promise<Array<Partial<TpJobseekerProfile>>> {
   const filterDesiredPositions =
     desiredPositions && desiredPositions.length !== 0
@@ -143,8 +143,8 @@ export async function fetchAllTpJobseekerProfiles({
       ? { inq: federalStates }
       : undefined
 
-  const filterJobFair2022Participant = isJobFair2022Participant
-    ? { isJobFair2022Participant: true }
+  const filterJobFair2023Participant = isJobFair2023Participant
+    ? { isJobFair2023Participant: true }
     : undefined
 
   return http(
@@ -172,7 +172,7 @@ export async function fetchAllTpJobseekerProfiles({
               { willingToRelocate: true },
             ],
           },
-          { ...filterJobFair2022Participant },
+          { ...filterJobFair2023Participant },
         ],
       },
       order: 'createdAt DESC',

--- a/libs/shared-types/src/lib/TpJobseekerProfile.ts
+++ b/libs/shared-types/src/lib/TpJobseekerProfile.ts
@@ -51,7 +51,7 @@ export type TpJobseekerProfile = {
   gaveGdprConsentAt: Date
 
   hrSummit2021JobFairCompanyJobPreferences?: HrSummit2021JobFairCompanyJobPreferenceRecord[]
-  isJobFair2022Participant?: boolean
+  isJobFair2023Participant?: boolean
 
   isProfileVisibleToCompanies: boolean
   isHired: boolean


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

## What should the reviewer know?
This PR adds a special toggle for the ReDI Job Fair 2023. Three important additions in the codebase for this are:

- Adding a Checkbox in the Jobseeker Account/Profile page, to allow them check the box if they are participating ReDI Job Fair 2023
- Adding a Checkbox in the Browsing Jobseekers page for companies to filter jobseekers that attend the Job Fair.
- Adding a visible information section in the Admin Panel, for ReDI Admins to see if a jobseeker attends the Job Fair.

## Screenshots
![CleanShot 2022-12-02 at 19 21 27@2x](https://user-images.githubusercontent.com/6314657/205360057-d3115055-0d3b-4318-876f-7c88f0698990.png)

![CleanShot 2022-12-02 at 19 21 05@2x](https://user-images.githubusercontent.com/6314657/205359994-b7f77120-a4b8-420c-98dd-9f46bd82221e.png)

![CleanShot 2022-12-02 at 19 21 38@2x](https://user-images.githubusercontent.com/6314657/205360119-6b4df807-d7e2-4ebb-a4c0-a9010a0621a0.png)
