### PR TITLE
fix(tp/con): open cards in a new tab

### DIFF
--- a/apps/api/lib/email/tp-templates/jobseeker-validate-email-address-successful.mjml
+++ b/apps/api/lib/email/tp-templates/jobseeker-validate-email-address-successful.mjml
@@ -14,7 +14,9 @@
             >your email address was successfully verified.</mj-text
           >
           <mj-text mj-class="text paragraph"
-            >Now, it's time to log into Talent Pool and work on your profile.
+            >Now, it's time to log into <a href="https://talent-pool.redi-school.org/front/login" 
+               class="text-link"
+               >Talent Pool</a> and work on your profile.
             Once it's complete, you will be able to send it to me for review.
           </mj-text>
           <mj-text mj-class="text paragraph"

--- a/apps/redi-connect/src/components/organisms/ProfileCard.scss
+++ b/apps/redi-connect/src/components/organisms/ProfileCard.scss
@@ -1,16 +1,16 @@
 @import '_variables.scss';
 
+.profile-card-link:hover {
+  text-decoration: none;
+}
+
 .profile-card {
   border-radius: 4px;
   height: 24.5rem;
   overflow: hidden;
 
-  &--active {
-    cursor: pointer;
-
-    &:hover {
-      box-shadow: $card-shadow-hover;
-    }
+  &:hover {
+    box-shadow: $card-shadow-hover;
   }
 
   &__name {

--- a/apps/redi-connect/src/components/organisms/ProfileCard.tsx
+++ b/apps/redi-connect/src/components/organisms/ProfileCard.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
-import classnames from 'classnames'
+import { NavLink } from 'react-router-dom'
 import { Card, Element, Tag } from 'react-bulma-components'
 import { Icon, PipeList } from '@talent-connect/shared-atomic-design-components'
 
-import { useHistory } from 'react-router-dom'
 import {
   AWS_PROFILE_AVATARS_BUCKET_BASE_URL,
   REDI_LOCATION_NAMES,
@@ -28,7 +27,6 @@ const ProfileCard = ({
   toggleFavorite,
   isFavorite,
 }: ProfileCardProps) => {
-  const history = useHistory()
 
   const {
     firstName,
@@ -44,49 +42,47 @@ const ProfileCard = ({
     toggleFavorite && toggleFavorite(profile.id)
   }
 
-  const handleLinkTo = () => linkTo && history.push(linkTo)
-
   const imgSrc = profileAvatarImageS3Key
     ? AWS_PROFILE_AVATARS_BUCKET_BASE_URL + profileAvatarImageS3Key
     : placeholderImage
 
   return (
-    <Card
-      className={classnames('profile-card', { 'profile-card--active': linkTo })}
-      onClick={linkTo ? handleLinkTo : undefined}
-    >
-      <Card.Image
-        className="profile-card__image"
-        src={imgSrc}
-        alt={`${firstName} ${lastName}`}
-      />
-      <Card.Content>
-        {toggleFavorite && (
-          <div className="profile-card__favorite" onClick={handleFavorite}>
-            <Icon
-              icon={isFavorite ? 'heartFilled' : 'heart'}
-              className="profile-card__favorite__icon"
-            />
-          </div>
-        )}
-        <Element
-          key="name"
-          renderAs="h3"
-          textWeight="bold"
-          textSize={4}
-          className="profile-card__name"
-        >
-          {firstName} {lastName}
-        </Element>
-        <Element key="location" renderAs="span" className="content">
-          {REDI_LOCATION_NAMES[rediLocation]}
-        </Element>
-        {languages && <PipeList items={languages} />}
-        {categories && (
-          <ReadMentoringTopics.Tags items={categories} shortList />
-        )}
-      </Card.Content>
-    </Card>
+    <NavLink to={linkTo} className="profile-card-link">
+      <Card className="profile-card">
+        <Card.Image
+          className="profile-card__image"
+          src={imgSrc}
+          alt={`${firstName} ${lastName}`}
+        />
+        <Card.Content>
+          {toggleFavorite && (
+            <div className="profile-card__favorite" onClick={handleFavorite}>
+              <Icon
+                icon={isFavorite ? 'heartFilled' : 'heart'}
+                className="profile-card__favorite__icon"
+              />
+            </div>
+          )}
+          <Element
+            key="name"
+            renderAs="h3"
+            textWeight="bold"
+            textSize={4}
+            className="profile-card__name"
+          >
+            {firstName} {lastName}
+          </Element>
+          <Element key="location" renderAs="span" className="content">
+            {REDI_LOCATION_NAMES[rediLocation]}
+          </Element>
+          {languages && <PipeList items={languages} />}
+          {categories && (
+            <ReadMentoringTopics.Tags items={categories} shortList />
+          )}
+        </Card.Content>
+      </Card>
+    </NavLink>
+    
   )
 }
 

--- a/apps/redi-connect/src/components/organisms/ProfileCard.tsx
+++ b/apps/redi-connect/src/components/organisms/ProfileCard.tsx
@@ -38,7 +38,7 @@ const ProfileCard = ({
   } = profile
 
   const handleFavorite = (e: React.MouseEvent) => {
-    e.stopPropagation()
+    e.preventDefault()
     toggleFavorite && toggleFavorite(profile.id)
   }
 

--- a/apps/redi-talent-pool/src/components/organisms/JobListingCard.scss
+++ b/apps/redi-talent-pool/src/components/organisms/JobListingCard.scss
@@ -1,16 +1,16 @@
 @import '_variables.scss';
 
+.job-posting-link:hover {
+  text-decoration: none;
+}
+
 .job-posting-card {
   border-radius: 4px;
   height: 24.5rem;
   overflow: hidden;
 
-  &--active {
-    cursor: pointer;
-
-    &:hover {
-      box-shadow: $card-shadow-hover;
-    }
+  &:hover {
+    box-shadow: $card-shadow-hover;
   }
 
   &__job-title {
@@ -52,3 +52,5 @@
     }
   }
 }
+
+

--- a/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
@@ -14,14 +14,14 @@ interface JobListingCardProps {
   isFavorite?: boolean
   toggleFavorite?: (id: string) => void
   linkTo?: string
-  onClick?: (e: React.MouseEvent) => void
+  onClick?: () => void
 }
 
 export function JobListingCard({
   jobListing,
   toggleFavorite,
   isFavorite,
-  linkTo,
+  linkTo = '#',
   onClick,
 }: JobListingCardProps) {
   const jobTitle = jobListing?.title
@@ -30,6 +30,14 @@ export function JobListingCard({
   const companyName = jobListing?.tpCompanyProfile?.companyName
   const companyAvatarImage =
     jobListing?.tpCompanyProfile?.profileAvatarImageS3Key
+
+  let actualOnClick
+  if (onClick) {
+    actualOnClick = (e: React.MouseEvent) => {
+      e.preventDefault()
+      onClick()
+    }
+  }
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -41,7 +49,7 @@ export function JobListingCard({
     : null
 
   return (
-    <NavLink to={linkTo} onClick={onClick} className="job-posting-link">
+    <NavLink to={linkTo} onClick={actualOnClick} className="job-posting-link">
       <Card className="job-posting-card">
         <Card.Image
           className="job-posting-card__image"

--- a/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
@@ -32,7 +32,7 @@ export function JobListingCard({
     jobListing?.tpCompanyProfile?.profileAvatarImageS3Key
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
-    e.stopPropagation()
+    e.preventDefault()
     toggleFavorite && toggleFavorite(jobListing.id)
   }
 

--- a/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
@@ -14,6 +14,7 @@ interface JobListingCardProps {
   isFavorite?: boolean
   toggleFavorite?: (id: string) => void
   linkTo?: string
+  onClick?: () => void
 }
 
 export function JobListingCard({
@@ -21,8 +22,8 @@ export function JobListingCard({
   toggleFavorite,
   isFavorite,
   linkTo,
+  onClick,
 }: JobListingCardProps) {
-
   const jobTitle = jobListing?.title
   const idealTechnicalSkills = jobListing?.idealTechnicalSkills
 
@@ -40,7 +41,7 @@ export function JobListingCard({
     : null
 
   return (
-    <NavLink to={linkTo} className="job-posting-link">
+    <NavLink to={linkTo} onClick={onClick} className="job-posting-link">
       <Card className="job-posting-card">
         <Card.Image
           className="job-posting-card__image"
@@ -85,6 +86,5 @@ export function JobListingCard({
         </Card.Content>
       </Card>
     </NavLink>
-    
   )
 }

--- a/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import classnames from 'clsx'
+import { NavLink } from 'react-router-dom'
 import { Card, Element } from 'react-bulma-components'
 
 import { CardTags, Icon } from '@talent-connect/shared-atomic-design-components'
@@ -11,18 +11,17 @@ import './JobListingCard.scss'
 
 interface JobListingCardProps {
   jobListing: Partial<TpJobListing>
-  onClick?: () => void
   isFavorite?: boolean
   toggleFavorite?: (id: string) => void
+  linkTo?: string
 }
 
 export function JobListingCard({
   jobListing,
-  onClick,
   toggleFavorite,
   isFavorite,
+  linkTo,
 }: JobListingCardProps) {
-  // const history = useHistory()
 
   const jobTitle = jobListing?.title
   const idealTechnicalSkills = jobListing?.idealTechnicalSkills
@@ -41,53 +40,51 @@ export function JobListingCard({
     : null
 
   return (
-    <Card
-      className={classnames('job-posting-card', {
-        'job-posting-card--active': onClick,
-      })}
-      onClick={onClick}
-    >
-      <Card.Image
-        className="job-posting-card__image"
-        src={imgSrc}
-        alt={jobTitle}
-      />
-      <Card.Content>
-        {toggleFavorite && (
-          <div
-            className="job-posting-card__favorite"
-            onClick={handleFavoriteClick}
+    <NavLink to={linkTo} className="job-posting-link">
+      <Card className="job-posting-card">
+        <Card.Image
+          className="job-posting-card__image"
+          src={imgSrc}
+          alt={jobTitle}
+        />
+        <Card.Content>
+          {toggleFavorite && (
+            <div
+              className="job-posting-card__favorite"
+              onClick={handleFavoriteClick}
+            >
+              <Icon
+                icon={isFavorite ? 'heartFilled' : 'heart'}
+                className="job-posting-card__favorite__icon"
+              />
+            </div>
+          )}
+          <Element
+            key="name"
+            renderAs="h3"
+            textWeight="bold"
+            textSize={4}
+            className="job-posting-card__job-title"
           >
-            <Icon
-              icon={isFavorite ? 'heartFilled' : 'heart'}
-              className="job-posting-card__favorite__icon"
+            {jobTitle}
+          </Element>
+          <Element
+            className="content job-posting-card__company-name"
+            key="location"
+            renderAs="div"
+          >
+            {companyName}
+          </Element>
+          {idealTechnicalSkills?.length > 0 ? (
+            <CardTags
+              items={idealTechnicalSkills}
+              shortList
+              formatter={(skill: string) => topSkillsIdToLabelMap[skill]}
             />
-          </div>
-        )}
-        <Element
-          key="name"
-          renderAs="h3"
-          textWeight="bold"
-          textSize={4}
-          className="job-posting-card__job-title"
-        >
-          {jobTitle}
-        </Element>
-        <Element
-          className="content job-posting-card__company-name"
-          key="location"
-          renderAs="div"
-        >
-          {companyName}
-        </Element>
-        {idealTechnicalSkills?.length > 0 ? (
-          <CardTags
-            items={idealTechnicalSkills}
-            shortList
-            formatter={(skill: string) => topSkillsIdToLabelMap[skill]}
-          />
-        ) : null}
-      </Card.Content>
-    </Card>
+          ) : null}
+        </Card.Content>
+      </Card>
+    </NavLink>
+    
   )
 }

--- a/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
@@ -14,7 +14,7 @@ interface JobListingCardProps {
   isFavorite?: boolean
   toggleFavorite?: (id: string) => void
   linkTo?: string
-  onClick?: () => void
+  onClick?: (e: React.MouseEvent) => void
 }
 
 export function JobListingCard({

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.scss
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.scss
@@ -1,16 +1,16 @@
 @import '_variables.scss';
 
+.jobseeker-profile-link:hover {
+  text-decoration: none;
+}
+
 .jobseeker-profile-card {
   border-radius: 4px;
   height: 24.5rem;
   overflow: hidden;
 
-  &--active {
-    cursor: pointer;
-
-    &:hover {
-      box-shadow: $card-shadow-hover;
-    }
+  &:hover {
+    box-shadow: $card-shadow-hover;
   }
 
   &__job-title {

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
@@ -32,7 +32,7 @@ export function JobseekerProfileCard({
   const topSkills = jobseekerProfile?.topSkills
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
-    e.stopPropagation()
+    e.preventDefault()
     toggleFavorite && toggleFavorite(jobseekerProfile.id)
   }
 

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
@@ -1,3 +1,4 @@
+import { NavLink } from 'react-router-dom'
 import { CardTags, Icon } from '@talent-connect/shared-atomic-design-components'
 import { AWS_PROFILE_AVATARS_BUCKET_BASE_URL } from '@talent-connect/shared-config'
 import { TpJobseekerProfile } from '@talent-connect/shared-types'
@@ -5,25 +6,23 @@ import {
   desiredPositionsIdToLabelMap,
   topSkillsIdToLabelMap,
 } from '@talent-connect/talent-pool/config'
-import classnames from 'clsx'
 import React from 'react'
 import { Card, Element, Tag } from 'react-bulma-components'
 import './JobseekerProfileCard.scss'
 import placeholderImage from '../../assets/img-placeholder.png'
 interface JobseekerProfileCardProps {
   jobseekerProfile: Partial<TpJobseekerProfile>
-  onClick?: () => void
+  linkTo?: string
   isFavorite?: boolean
   toggleFavorite?: (id: string) => void
 }
 
 export function JobseekerProfileCard({
   jobseekerProfile,
-  onClick,
+  linkTo,
   toggleFavorite,
   isFavorite,
 }: JobseekerProfileCardProps) {
-  // const history = useHistory()
 
   const fullName = `${jobseekerProfile?.firstName} ${jobseekerProfile?.lastName}`
   const desiredPositions =
@@ -43,56 +42,53 @@ export function JobseekerProfileCard({
     : placeholderImage
 
   return (
-    <Card
-      className={classnames('jobseeker-profile-card', {
-        'jobseeker-profile-card--active': onClick,
-      })}
-      onClick={onClick}
-    >
-      <Card.Image
-        className="jobseeker-profile-card__image"
-        src={imgSrc}
-        alt={fullName}
-      />
-      <Card.Content>
-        {jobseekerProfile.isHired ? (
-          <Tag className="jobseeker-profile-card__hired-tag">HIRED!</Tag>
-        ) : null}
-        {toggleFavorite && (
-          <div
-            className="jobseeker-profile-card__favorite"
-            onClick={handleFavoriteClick}
+    <NavLink to={linkTo} className="jobseeker-profile-link">
+      <Card className="jobseeker-profile-card">
+        <Card.Image
+          className="jobseeker-profile-card__image"
+          src={imgSrc}
+          alt={fullName}
+        />
+        <Card.Content>
+          {jobseekerProfile.isHired ? (
+            <Tag className="jobseeker-profile-card__hired-tag">HIRED!</Tag>
+          ) : null}
+          {toggleFavorite && (
+            <div
+              className="jobseeker-profile-card__favorite"
+              onClick={handleFavoriteClick}
+            >
+              <Icon
+                icon={isFavorite ? 'heartFilled' : 'heart'}
+                className="jobseeker-profile-card__favorite__icon"
+              />
+            </div>
+          )}
+          <Element
+            key="name"
+            renderAs="h3"
+            textWeight="bold"
+            textSize={4}
+            className="jobseeker-profile-card__job-title"
           >
-            <Icon
-              icon={isFavorite ? 'heartFilled' : 'heart'}
-              className="jobseeker-profile-card__favorite__icon"
+            {fullName}
+          </Element>
+          <Element
+            className="content jobseeker-profile-card__company-name"
+            key="location"
+            renderAs="div"
+          >
+            {desiredPositions}
+          </Element>
+          {topSkills?.length > 0 ? (
+            <CardTags
+              items={topSkills}
+              shortList
+              formatter={(skill: string) => topSkillsIdToLabelMap[skill]}
             />
-          </div>
-        )}
-        <Element
-          key="name"
-          renderAs="h3"
-          textWeight="bold"
-          textSize={4}
-          className="jobseeker-profile-card__job-title"
-        >
-          {fullName}
-        </Element>
-        <Element
-          className="content jobseeker-profile-card__company-name"
-          key="location"
-          renderAs="div"
-        >
-          {desiredPositions}
-        </Element>
-        {topSkills?.length > 0 ? (
-          <CardTags
-            items={topSkills}
-            shortList
-            formatter={(skill: string) => topSkillsIdToLabelMap[skill]}
-          />
-        ) : null}
-      </Card.Content>
-    </Card>
+          ) : null}
+        </Card.Content>
+      </Card>
+    </NavLink>
   )
 }

--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
@@ -120,6 +120,7 @@ export function EditableJobPostings({
                     key={jobListing.id}
                     jobListing={jobListing}
                     onClick={() => startEditing(jobListing.id)}
+                    linkTo="#"
                   />
                 </Columns.Column>
               ))}

--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
@@ -63,6 +63,11 @@ export function EditableJobPostings({
     }
   }, [isEditing, setIsJobPostingFormOpen])
 
+  const handleStartEditingClick = (id, e: React.MouseEvent) => {
+    e.preventDefault()
+    startEditing(id)
+  }
+
   return (
     <>
       <div className="profile-section">
@@ -119,7 +124,7 @@ export function EditableJobPostings({
                   <JobListingCard
                     key={jobListing.id}
                     jobListing={jobListing}
-                    onClick={() => startEditing(jobListing.id)}
+                    onClick={(e) => handleStartEditingClick(jobListing.id, e)}
                     linkTo="#"
                   />
                 </Columns.Column>

--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
@@ -63,11 +63,6 @@ export function EditableJobPostings({
     }
   }, [isEditing, setIsJobPostingFormOpen])
 
-  const handleStartEditingClick = (id, e: React.MouseEvent) => {
-    e.preventDefault()
-    startEditing(id)
-  }
-
   return (
     <>
       <div className="profile-section">
@@ -124,8 +119,7 @@ export function EditableJobPostings({
                   <JobListingCard
                     key={jobListing.id}
                     jobListing={jobListing}
-                    onClick={(e) => handleStartEditingClick(jobListing.id, e)}
-                    linkTo="#"
+                    onClick={() => startEditing(jobListing.id)}
                   />
                 </Columns.Column>
               ))}

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react'
-import { useHistory } from 'react-router'
 import {
   ArrayParam,
   BooleanParam,
@@ -60,8 +58,6 @@ export function BrowseCompany() {
     onlyFavorites,
     isJobFair2023Participant,
   } = query
-
-  const history = useHistory()
 
   const { data: jobseekerProfiles } = useBrowseTpJobseekerProfilesQuery({
     name,
@@ -292,9 +288,7 @@ export function BrowseCompany() {
               <JobseekerProfileCard
                 key={profile.id}
                 jobseekerProfile={profile}
-                onClick={() =>
-                  history.push(`/app/jobseeker-profile/${profile.id}`)
-                }
+                linkTo={`/app/jobseeker-profile/${profile.id}`}
                 toggleFavorite={handleFavoriteJobseeker}
                 isFavorite={isFavorite}
               />

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useHistory } from 'react-router-dom'
+import { useHistory, Link } from 'react-router-dom'
 import { Columns, Element, Tag } from 'react-bulma-components'
 import {
   ArrayParam,
@@ -266,15 +266,19 @@ export function BrowseJobseeker() {
 
             return (
               <Columns.Column mobile={{ size: 12 }} tablet={{ size: 6 }}>
+                <Link to={`/app/job-listing/${jobListing.id}`} onClick={() =>
+                    history.push(`/app/job-listing/${jobListing.id}`)
+                  }>
                 <JobListingCard
                   key={jobListing.id}
                   jobListing={jobListing}
-                  onClick={() =>
-                    history.push(`/app/job-listing/${jobListing.id}`)
-                  }
+                  // onClick={() =>
+                  //   history.push(`/app/job-listing/${jobListing.id}`)
+                  // }
                   toggleFavorite={handleFavoriteJobListing}
                   isFavorite={isFavorite}
                 />
+                </Link>
               </Columns.Column>
             )
           })}

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useHistory, Link } from 'react-router-dom'
 import { Columns, Element, Tag } from 'react-bulma-components'
 import {
   ArrayParam,
@@ -53,8 +52,6 @@ export function BrowseJobseeker() {
     onlyFavorites,
     isRemotePossible,
   } = query
-
-  const history = useHistory()
 
   const { data: jobseekerProfile } = useTpJobseekerProfileQuery()
   const tpjobseekerprofileUpdateMutation = useTpjobseekerprofileUpdateMutation()
@@ -266,19 +263,13 @@ export function BrowseJobseeker() {
 
             return (
               <Columns.Column mobile={{ size: 12 }} tablet={{ size: 6 }}>
-                <Link to={`/app/job-listing/${jobListing.id}`} onClick={() =>
-                    history.push(`/app/job-listing/${jobListing.id}`)
-                  }>
                 <JobListingCard
                   key={jobListing.id}
                   jobListing={jobListing}
-                  // onClick={() =>
-                  //   history.push(`/app/job-listing/${jobListing.id}`)
-                  // }
                   toggleFavorite={handleFavoriteJobListing}
                   isFavorite={isFavorite}
+                  linkTo={`/app/job-listing/${jobListing.id}`}
                 />
-                </Link>
               </Columns.Column>
             )
           })}

--- a/apps/redi-talent-pool/src/pages/front/signup/SignUpComplete.tsx
+++ b/apps/redi-talent-pool/src/pages/front/signup/SignUpComplete.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@talent-connect/shared-atomic-design-components'
 import { UserType } from '@talent-connect/shared-types'
 import { Columns, Content, Form } from 'react-bulma-components'
+import TpTeaser from '../../../components/molecules/TpTeaser'
 import { useHistory, useParams } from 'react-router'
 import AccountOperation from '../../../components/templates/AccountOperation'
 
@@ -18,7 +19,7 @@ export default function SignUpComplete() {
         <Columns.Column
           size={5}
           responsive={{ mobile: { hide: { value: true } } }}
-        ></Columns.Column>
+        ><TpTeaser.IllustrationOnly /></Columns.Column>
         <Columns.Column size={5} offset={2}>
           <Content size="large" renderAs="div">
             <p>Your email address was successfully verified!</p>


### PR DESCRIPTION
## What should the reviewer know?

In this PR, the following miscellaneous fixes were made:

1. Added link for the TP website to the jobseeker "validate successful" e-mail.
<img width="673" alt="image" src="https://user-images.githubusercontent.com/51786805/218098220-08a5862c-e2e1-4289-b151-44d954bb5ef4.png">

2. Added an illustration to the TP sign-up complete page (the blue side on the left was empty before).
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/51786805/218098064-e0d29b8e-b2eb-4e43-84c9-e9c4185a3ee6.png">

3. Made a job posting & jobseeker profile card to open in a new tab (ticket [#547](https://github.com/talent-connect/connect/issues/547)).
![image](https://user-images.githubusercontent.com/51786805/218097889-b52a7bfa-81c1-4e90-909e-5afc80426974.png)
<img width="855" alt="image" src="https://user-images.githubusercontent.com/51786805/218579107-755faa61-6900-4c04-9078-ad06e0272427.png">

4. Made a mentor/mentee profile card to open in a new tab (ticket [#656](https://github.com/talent-connect/connect/issues/656).
![image](https://user-images.githubusercontent.com/51786805/218766294-59db459e-a850-4adb-aad3-97f8ab648783.png)