### PR TITLE
feat(tp): Add filter job listings posted by companies attending the Job Fair

### DIFF
--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -212,6 +212,7 @@ export function BrowseCompany() {
         </div>
       </div>
       <div className="filters">
+        {/* Hidden until the next Job Fair date announced */}
         <div className="filters-inner filters__jobfair">
           <Checkbox
             name="isJobFair2023Participant"

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -213,7 +213,7 @@ export function BrowseCompany() {
       </div>
       <div className="filters">
         {/* Hidden until the next Job Fair date announced */}
-        <div className="filters-inner filters__jobfair">
+        {/* <div className="filters-inner filters__jobfair">
           <Checkbox
             name="isJobFair2023Participant"
             checked={isJobFair2023Participant || false}
@@ -221,7 +221,7 @@ export function BrowseCompany() {
           >
             Attending ReDI Job Fair 2023
           </Checkbox>
-        </div>
+        </div> */}
         <div
           className="filters-inner filter-favourites"
           onClick={toggleOnlyFavoritesFilter}

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
@@ -210,7 +210,7 @@ export function BrowseJobseeker() {
           Remote Working Possible
         </div>
         {/* Hidden until the next Job Fair date announced */}
-        <div className="filters-inner filters__jobfair">
+        {/* <div className="filters-inner filters__jobfair">
           <Checkbox
             name="isJobFair2023Participant"
             checked={isJobFair2023Participant || false}
@@ -218,7 +218,7 @@ export function BrowseJobseeker() {
           >
             Attending ReDI Job Fair 2023
           </Checkbox>
-        </div>
+        </div> */}
       </div>
       <div className="active-filters">
         {(relatedPositions.length !== 0 ||

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
@@ -43,6 +43,7 @@ export function BrowseJobseeker() {
     federalStates: withDefault(ArrayParam, []),
     onlyFavorites: withDefault(BooleanParam, undefined),
     isRemotePossible: withDefault(BooleanParam, undefined),
+    isJobFair2023Participant: withDefault(BooleanParam, undefined),
   })
   const {
     relatedPositions,
@@ -51,6 +52,7 @@ export function BrowseJobseeker() {
     federalStates,
     onlyFavorites,
     isRemotePossible,
+    isJobFair2023Participant,
   } = query
 
   const { data: jobseekerProfile } = useTpJobseekerProfileQuery()
@@ -62,6 +64,7 @@ export function BrowseJobseeker() {
     employmentType,
     federalStates,
     isRemotePossible,
+    isJobFair2023Participant,
   })
 
   const handleFavoriteJobListing = (value) => {
@@ -93,12 +96,20 @@ export function BrowseJobseeker() {
     setQuery((latestQuery) => ({ ...latestQuery, [filterName]: newFilters }))
   }
 
+  const toggleJobFair2023Filter = () =>
+    setQuery((latestQuery) => ({
+      ...latestQuery,
+      isJobFair2023Participant:
+        isJobFair2023Participant === undefined ? true : undefined,
+    }))
+
   const clearFilters = () => {
     setQuery((latestQuery) => ({
       ...latestQuery,
       idealTechnicalSkills: [],
       employmentType: [],
       federalStates: [],
+      isJobFair2023Participant: undefined,
     }))
   }
 
@@ -198,6 +209,16 @@ export function BrowseJobseeker() {
           {isRemotePossible ? <Home /> : <HomeOutlined />}
           Remote Working Possible
         </div>
+        {/* Hidden until the next Job Fair date announced */}
+        <div className="filters-inner filters__jobfair">
+          <Checkbox
+            name="isJobFair2023Participant"
+            checked={isJobFair2023Participant || false}
+            handleChange={toggleJobFair2023Filter}
+          >
+            Attending ReDI Job Fair 2023
+          </Checkbox>
+        </div>
       </div>
       <div className="active-filters">
         {(relatedPositions.length !== 0 ||
@@ -239,6 +260,14 @@ export function BrowseJobseeker() {
                 }
               />
             ))}
+            {isJobFair2023Participant && (
+              <FilterTag
+                key="redi-job-fair-2022-filter"
+                id="redi-job-fair-2022-filter"
+                label="Attending ReDI Job Fair 2023"
+                onClickHandler={toggleJobFair2023Filter}
+              />
+            )}
             <span className="active-filters__clear-all" onClick={clearFilters}>
               Delete all filters
               <Icon icon="cancel" size="small" space="left" />

--- a/apps/redi-talent-pool/src/pages/app/me/MeCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/MeCompany.tsx
@@ -141,7 +141,7 @@ export function MeCompany() {
         <Columns.Column mobile={{ size: 12 }} tablet={{ size: 'three-fifths' }}>
           <EditableNamePhotoLocation profile={profile} />
           {/* Hidden until the next Job Fair date announced */}
-          <div style={{ marginBottom: '1.5rem' }}>
+          {/* <div style={{ marginBottom: '1.5rem' }}>
             <Checkbox
               checked={profile.isJobFair2023Participant}
               customOnChange={onJobFair2023ParticipateChange}
@@ -149,7 +149,7 @@ export function MeCompany() {
               My company will attend the <strong>ReDI Job Fair</strong>{' '}
               happening on <strong>15/02/2023</strong>.
             </Checkbox>
-          </div>
+          </div> */}
           <EditableAbout profile={profile} />
         </Columns.Column>
         <Columns.Column mobile={{ size: 12 }} tablet={{ size: 'two-fifths' }}>

--- a/apps/redi-talent-pool/src/pages/app/me/MeCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/MeCompany.tsx
@@ -140,6 +140,7 @@ export function MeCompany() {
       <Columns className="is-6 is-variable">
         <Columns.Column mobile={{ size: 12 }} tablet={{ size: 'three-fifths' }}>
           <EditableNamePhotoLocation profile={profile} />
+          {/* Hidden until the next Job Fair date announced */}
           <div style={{ marginBottom: '1.5rem' }}>
             <Checkbox
               checked={profile.isJobFair2023Participant}

--- a/apps/redi-talent-pool/src/pages/app/me/MeJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/MeJobseeker.tsx
@@ -77,7 +77,7 @@ export function MeJobseeker() {
           </div>
           <EditableNamePhotoLocation profile={profile} />
           {/* Hidden until the next Job Fair date announced */}
-          <div style={{ marginBottom: '1.5rem' }}>
+          {/* <div style={{ marginBottom: '1.5rem' }}>
             <Checkbox
               checked={profile.isJobFair2023Participant}
               customOnChange={onJobFair2023ParticipateChange}
@@ -85,7 +85,7 @@ export function MeJobseeker() {
               I will attend the <b>ReDI Job Fair</b> happening on{' '}
               <b>15/02/2023</b>.
             </Checkbox>
-          </div>
+          </div> */}
           <EditableOverview profile={profile} />
           <EditableSummary profile={profile} />
           <EditableProfessionalExperience profile={profile} />

--- a/apps/redi-talent-pool/src/pages/app/me/MeJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/MeJobseeker.tsx
@@ -76,6 +76,7 @@ export function MeJobseeker() {
             <OnboardingSteps />
           </div>
           <EditableNamePhotoLocation profile={profile} />
+          {/* Hidden until the next Job Fair date announced */}
           <div style={{ marginBottom: '1.5rem' }}>
             <Checkbox
               checked={profile.isJobFair2023Participant}

--- a/apps/redi-talent-pool/src/services/api/api.tsx
+++ b/apps/redi-talent-pool/src/services/api/api.tsx
@@ -298,6 +298,7 @@ export interface TpJobListingFilters {
   employmentType: string[]
   federalStates: string[]
   isRemotePossible: boolean
+  isJobFair2023Participant: boolean
 }
 
 export async function fetchAllTpJobListingsUsingFilters({
@@ -306,6 +307,7 @@ export async function fetchAllTpJobListingsUsingFilters({
   employmentType,
   federalStates,
   isRemotePossible,
+  isJobFair2023Participant,
 }: TpJobListingFilters): Promise<Array<TpJobListing>> {
   const filterRelatedPositions =
     relatedPositions && relatedPositions.length !== 0
@@ -353,6 +355,15 @@ export async function fetchAllTpJobListingsUsingFilters({
           listing.tpCompanyProfile?.isProfileVisibleToJobseekers &&
           listing.tpCompanyProfile.state === 'profile-approved'
       )
+      .filter((listing) => {
+        if (isJobFair2023Participant) {
+          const isPostedByCompanyJobFair2023Participant =
+            listing.tpCompanyProfile?.isJobFair2023Participant
+
+          return isPostedByCompanyJobFair2023Participant
+        }
+        return true
+      })
   )
 }
 


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Ticket #639

PR https://github.com/talent-connect/connect/pull/651

## What should the reviewer know?

- On the 'Browse job listings' page, added the checkbox filter so the job seekers can filter job listings posted by companies attending the Job Fair.
- Hid this checkbox from the Company profile, Jobseeker profile, and both 'Browse' pages until the next Job Fair date announced

@fortini, since here we are displaying job postings and not profiles of companies attending the Job Fair, we have to come up with a better name for this filter before we make it available to job seekers again.

## Screenshots
![image](https://user-images.githubusercontent.com/51786805/225084430-ef068a78-1b62-47b4-82d9-4392f397792f.png)
