### PR TITLE
feat(nestjs-api): cache data from sf for 5 min instead of 10 min

### DIFF
--- a/apps/api/scripts/.gitignore
+++ b/apps/api/scripts/.gitignore
@@ -1,3 +1,4 @@
 20210614-hr-summit-invite-to-companies.js
 .env
 .env.partialsandbox
+generate-jwt-token.js

--- a/apps/nestjs-api/src/salesforce-api/sf-api.repository.ts
+++ b/apps/nestjs-api/src/salesforce-api/sf-api.repository.ts
@@ -160,7 +160,7 @@ export class SfApiRepository {
 
       result.on('end', async () => {
         console.log('[SfApiRepository]', `Found ${records.length} records`)
-        await this.cacheManager.set(cacheKey, records, 60 * 10)
+        await this.cacheManager.set(cacheKey, records, 60 * 5)
         callback(records)
       })
 


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

None

## What should the reviewer know?

All queries returned from SF are currently cached for up to ten minutes before being cleared/invalidated. This PR adjusts this down to five minutes.

Do note that there are other things that clear/invalidate the cache:
- any mutations/writes
- certain events in Salesforce (such as approvals)