### PR TITLE
[CON/TP]: Handle the "unauthorized error" case when the JWT token expires

### DIFF
--- a/apps/api/common/models/red-user.js
+++ b/apps/api/common/models/red-user.js
@@ -144,7 +144,7 @@ module.exports = function (RedUser) {
       { ...loginOutput.toJSON(), email },
       process.env.NX_JWT_SECRET,
       {
-        expiresIn: '7d',
+        expiresIn: '21d',
       }
     )
     ctx.result.jwtToken = jwtToken

--- a/libs/data-access/src/lib/graphql-client.ts
+++ b/libs/data-access/src/lib/graphql-client.ts
@@ -11,13 +11,39 @@ export const graphqlClient = new GraphQLClient(endpoint, {
   // },
 })
 
+// Middleware to handle 401 errors
+const handleUnauthorizedError = (error: any) => {
+  if (error?.response?.errors?.length > 0) {
+    const responseError = error.response.errors[0]
+
+    if (responseError?.extensions) {
+      const extensionResponse = responseError.extensions.response
+
+      if (extensionResponse?.statusCode === 401) {
+        alert('Your session has expired. Please log in again.')
+        window.localStorage.clear()
+        window.location.replace('/front/login')
+      }
+    }
+  }
+}
+
 export function fetcher<TData, TVariables>(
   query: string,
   variables?: TVariables,
   headers?: RequestInit['headers']
 ) {
-  return async (): Promise<TData> =>
-    graphqlClient.request<TData, TVariables>(query, variables, headers)
+  return async (): Promise<TData> => {
+    return new Promise((resolve, reject) => {
+      graphqlClient
+        .request<TData, TVariables>(query, variables, headers)
+        .then(resolve)
+        .catch((error) => {
+          handleUnauthorizedError(error)
+          reject(error)
+        })
+    })
+  }
 }
 
 // export type TestQueryVariables = Types.Exact<{ [key: string]: never }>


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#728 

## What should the reviewer know?
This PR handles the situations where the JWT token expires, graphql returns 401 but Frontend cannot handle it. Now the middleware will alert the user that their session has expired, clear the localstorage and redirect them to the login page.

More information can be seen in the ticket above.