### PR TITLE
[TP/Browse page] Adds the total number of Job Postings /Jobseekers 

### DIFF
--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -166,6 +166,7 @@ export function BrowseCompany() {
         style={{ flexGrow: 1 }}
       >
         Browse our Talent Pool
+        {jobseekerProfiles?.length ? ` (${jobseekerProfiles.length})` : ''}
       </Element>
       <Element
         renderAs="p"

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
@@ -153,7 +153,8 @@ export function BrowseJobseeker() {
         className="is-flex-grow-1"
         style={{ flexGrow: 1 }}
       >
-        Browse open Job Listings
+        Browse open Job Listings{' '}
+        {jobListings?.length ? `(${jobListings.length})` : ''}
       </Element>
       <Element
         renderAs="p"


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#699 

## What should the reviewer know?

This PR adds the total number of Job Postings /Jobseekers to the title of the search in the Browse page.

Previous Title in Browse page for Jobseekers:
![231462904-907e7dad-370a-42af-ae20-012c31002218](https://github.com/talent-connect/connect/assets/62472348/e1d2800a-f765-4e0a-a7dd-cea901b538ef)

Current Title in Browse page for Jobseekers:
<img width="1144" alt="Screenshot 2023-05-09 at 13 03 01" src="https://github.com/talent-connect/connect/assets/62472348/59e8af08-c9b2-490c-b7e4-b2b0d00ecdd5">


Previous Title in Browse page for Companies:
![231463610-051dec83-f084-4026-9351-34abdded349e](https://github.com/talent-connect/connect/assets/62472348/d8606e38-4c84-465e-899f-0d5ce7a94577)

Current Title in Browse page for Companies:
<img width="1141" alt="Screenshot 2023-05-09 at 13 02 39" src="https://github.com/talent-connect/connect/assets/62472348/dc82abe5-c928-4d67-874f-2bf2e5819f94">
