### PR TITLE
fix(tp): save education and experience records one by one

### DIFF
--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableEducation.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableEducation.tsx
@@ -209,8 +209,8 @@ function JobseekerFormSectionEducation({
 
     const deletedRecords = removedRecords.current
 
-    const createRecordPromises = newRecords.map((record) => {
-      return createMutation.mutateAsync({
+    for (const record of newRecords) {
+      await createMutation.mutateAsync({
         input: {
           certificationType: record.certificationType,
           current: record.current,
@@ -226,10 +226,10 @@ function JobseekerFormSectionEducation({
           title: record.title,
         },
       })
-    })
+    }
 
-    const patchRecordPromises = existingRecords.map((record) => {
-      return patchMutation.mutateAsync({
+    for (const record of existingRecords) {
+      await patchMutation.mutateAsync({
         input: {
           id: record.id,
           certificationType: record.certificationType,
@@ -246,22 +246,17 @@ function JobseekerFormSectionEducation({
           title: record.title,
         },
       })
-    })
+    }
 
-    const deleteRecordPromises = deletedRecords.map((recordId) => {
-      return deleteMutation.mutateAsync({
+    for (const recordId of deletedRecords) {
+      await deleteMutation.mutateAsync({
         input: {
           id: recordId,
         },
       })
-    })
+    }
 
     formik.setSubmitting(true)
-    await Promise.all([
-      ...createRecordPromises,
-      ...patchRecordPromises,
-      ...deleteRecordPromises,
-    ])
     queryClient.invalidateQueries()
     formik.setSubmitting(false)
     setIsEditing(false)

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableProfessionalExperience.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableProfessionalExperience.tsx
@@ -213,8 +213,8 @@ export function JobseekerFormSectionProfessionalExperience({
 
     const deletedRecords = removedRecords.current
 
-    const createRecordPromises = newRecords.map((record) => {
-      return createMutation.mutateAsync({
+    for (const record of newRecords) {
+      await createMutation.mutateAsync({
         input: {
           city: record.city,
           company: record.company,
@@ -229,10 +229,10 @@ export function JobseekerFormSectionProfessionalExperience({
           title: record.title,
         },
       })
-    })
+    }
 
-    const patchRecordPromises = existingRecords.map((record) => {
-      return patchMutation.mutateAsync({
+    for (const record of existingRecords) {
+      await patchMutation.mutateAsync({
         input: {
           id: record.id,
           city: record.city,
@@ -248,22 +248,17 @@ export function JobseekerFormSectionProfessionalExperience({
           title: record.title,
         },
       })
-    })
+    }
 
-    const deleteRecordPromises = deletedRecords.map((recordId) => {
-      return deleteMutation.mutateAsync({
+    for (const recordId of deletedRecords) {
+      await deleteMutation.mutateAsync({
         input: {
           id: recordId,
         },
       })
-    })
+    }
 
     formik.setSubmitting(true)
-    await Promise.all([
-      ...createRecordPromises,
-      ...patchRecordPromises,
-      ...deleteRecordPromises,
-    ])
     queryClient.invalidateQueries()
     formik.setSubmitting(false)
     setIsEditing(false)


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Bug report: Some students have reported that it is not possible to add new education or experience records. 
This error may occur when users have many records or try to save/add many.

Screenshot of the error:
<img width="472" alt="image" src="https://github.com/talent-connect/connect/assets/51786805/d5ffcb3f-5cd1-4be2-9b1b-e73f65ee2cea">

## What should the reviewer know?

Here we use the same approach as when saving language records - we save them one by one.