### PR TITLE
Fix TP Login for accounts without CON profile

### DIFF
--- a/apps/redi-talent-pool/src/pages/front/login/Login.tsx
+++ b/apps/redi-talent-pool/src/pages/front/login/Login.tsx
@@ -1,11 +1,11 @@
 import {
+  fetcher,
   LoadMyProfileDocument,
   LoadMyProfileQuery,
   LoadMyProfileQueryVariables,
   MyTpDataDocument,
   MyTpDataQuery,
   MyTpDataQueryVariables,
-  fetcher,
 } from '@talent-connect/data-access'
 import {
   Button,
@@ -75,21 +75,25 @@ export default function Login() {
           saveAccessTokenToLocalStorage(accessToken)
 
           const tpUserData = await myTpDataFetcher()
+
+          const userHasATpProfile =
+            Boolean(
+              tpUserData.tpCurrentUserDataGet.tpJobseekerDirectoryEntry
+            ) || Boolean(tpUserData.tpCurrentUserDataGet.representedCompany)
+
+          if (userHasATpProfile) {
+            return history.push('/app/me')
+          }
+
           // Note: we have to "build" the con profile data fetcher here because it
           // relies on the access token, which is not available until after the user
           // has logged in.
           const myConProfileDataFetcher = buildMyConProfileDataFetcher()
           const conUserData = await myConProfileDataFetcher()
-          const userHasATpProfile =
-            Boolean(
-              tpUserData.tpCurrentUserDataGet.tpJobseekerDirectoryEntry
-            ) || Boolean(tpUserData.tpCurrentUserDataGet.representedCompany)
+
           const userDoesNotHaveTpProfile = !userHasATpProfile
           const userHasConProfile = Boolean(conUserData.conProfile)
 
-          if (userHasATpProfile) {
-            return history.push('/app/me')
-          }
           if (userDoesNotHaveTpProfile && userHasConProfile) {
             await tpJobseekerSignupMutation.mutateAsync({
               input: {


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
:x: When I log in to any of my existing TP users, I get this error (screenshot). No errors in the console, but if I go to the account, I can see my logged-in profile.

## What should the reviewer know?
This is happening because we try to load the CON profile for every TP user trying to log in, and if a CON profile doesn't exist, the graphql query returns 404, which is caught as an exception in the try catch block, thus stopping the whole process and sets the error messages in the login form.

We need to attempt loading the CON profile only when the TP profile for the RedUser doesn't exist, so we can create a new TP Profile based on that CON profile. If a TP Profile already exists, we can directly take the user to their account.
