### PR TITLE
fix(con/tp): revert the text for cross-platform login

### DIFF
--- a/apps/redi-connect/src/pages/front/login/Login.tsx
+++ b/apps/redi-connect/src/pages/front/login/Login.tsx
@@ -163,13 +163,8 @@ export default function Login() {
             Enter your email and password below.
           </Content>
           <Content size="small" renderAs="p">
-            {/* Commented and replaced with different text until the cross-platform log-in feature is implemented. */}
-            {/* Got a ReDI Talent Pool user account? You can use the same username
-            and password here. */}
-            Got a ReDI Talent Pool user account? To log in with the same
-            username and password get in contact with @Kate in ReDI Slack or
-            write an e-mail
-            <a href="mailto:kateryna@redi-school.org"> here</a>.
+            Got a ReDI Talent Pool user account? You can use the same username
+            and password here.
           </Content>
 
           {isWrongRediLocationError && (

--- a/apps/redi-connect/src/pages/front/signup/SignUp.tsx
+++ b/apps/redi-connect/src/pages/front/signup/SignUp.tsx
@@ -9,7 +9,7 @@ import {
   Checkbox,
   FormInput,
   FormSelect,
-  Heading
+  Heading,
 } from '@talent-connect/shared-atomic-design-components'
 import { FormikHelpers as FormikActions, FormikValues, useFormik } from 'formik'
 
@@ -21,7 +21,7 @@ import {
   RediCourse,
   RediLocation,
   useConProfileSignUpMutation,
-  UserType
+  UserType,
 } from '@talent-connect/data-access'
 import { COURSES } from '@talent-connect/shared-config'
 import { toPascalCaseAndTrim } from '@talent-connect/shared-utils'
@@ -160,12 +160,8 @@ export default function SignUp() {
           <Heading border="bottomLeft">Sign-up</Heading>
           {type === 'mentee' && (
             <Content size="small" renderAs="p">
-              {/* Commented and replaced with different text until the cross-platform log-in feature is implemented. */}
-              {/* Got a ReDI Talent Pool user account? You can log in with the same
-              username and password <Link to="/front/login">here</Link>. */}
-              Got a ReDI Talent Pool user account? To log in with the same username 
-              and password get in contact with @Kate in ReDI Slack or write an e-mail 
-              <a href="mailto:kateryna@redi-school.org"> here</a>.
+              Got a ReDI Talent Pool user account? You can log in with the same
+              username and password <Link to="/front/login">here</Link>.
             </Content>
           )}
           {loopbackSubmitError === 'user-already-exists' ? (

--- a/apps/redi-talent-pool/src/pages/front/login/Login.tsx
+++ b/apps/redi-talent-pool/src/pages/front/login/Login.tsx
@@ -137,13 +137,8 @@ export default function Login() {
             Enter your email and password below.
           </Content>
           <Content size="small" renderAs="p">
-            {/* Commented and replaced with different text until the cross-platform log-in feature is implemented. */}
-            {/* Got a ReDI Connect user account? You can use the same username and
-            password here. */}
-            Got a ReDI Connect user account? To log in with the same username
-            and password get in contact with @Kate in ReDI Slack or write an
-            e-mail
-            <a href="mailto:kateryna@redi-school.org"> here</a>.
+            Got a ReDI Connect user account? You can use the same username and
+            password here.
           </Content>
 
           <form onSubmit={(e) => e.preventDefault()}>

--- a/apps/redi-talent-pool/src/pages/front/signup/SignUp.tsx
+++ b/apps/redi-talent-pool/src/pages/front/signup/SignUp.tsx
@@ -1,13 +1,13 @@
 import {
   TpCompanyProfileSignUpOperationType,
-  useListAllTpCompanyNamesQuery
+  useListAllTpCompanyNamesQuery,
 } from '@talent-connect/data-access'
 import {
   Button,
   Checkbox,
   FormInput,
   FormSelect,
-  Heading
+  Heading,
 } from '@talent-connect/shared-atomic-design-components'
 import { COURSES, REDI_LOCATION_NAMES } from '@talent-connect/shared-config'
 import { TpCompanyProfile } from '@talent-connect/shared-types'
@@ -26,7 +26,7 @@ import { signUpLoopback } from '../../../services/api/api'
 import { history } from '../../../services/history/history'
 import {
   useSignUpCompanyMutation,
-  useSignUpJobseekerMutation
+  useSignUpJobseekerMutation,
 } from './SignUp.generated'
 
 const formRediLocations = objectEntries(REDI_LOCATION_NAMES).map(
@@ -121,7 +121,7 @@ export default function SignUp() {
       passwordConfirm: '',
       firstName: '',
       lastName: '',
-      isMicrosoftPartner: false
+      isMicrosoftPartner: false,
     }),
     []
   )
@@ -223,13 +223,8 @@ export default function SignUp() {
         <Columns.Column size={5} offset={1}>
           <Heading border="bottomLeft">Sign-up</Heading>
           <Content size="small" renderAs="p">
-            {/* Commented and replaced with different text until the cross-platform log-in feature is implemented. */}
-            {/* Got a ReDI Connect user account? You can log in with the same
-            username and password <Link to="/front/login">here</Link>. */}
-            Got a ReDI Connect user account? To log in with the same username
-            and password get in contact with @Kate in ReDI Slack or write an
-            e-mail
-            <a href="mailto:kateryna@redi-school.org"> here</a>.
+            Got a ReDI Connect user account? You can log in with the same
+            username and password <Link to="/front/login">here</Link>.
           </Content>
           {loopbackSubmitError === 'user-already-exists' && (
             <Notification color="info" className="is-light">


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

When the cross-platform login didn't work, we changed the text on Login and SignUp pages. Now as the feature has been re-implemented, we want to revert the previous text.