### PR TITLE
[CON]fix: Disables future dates + allows default values to be submitted on mentoring sessions #624

### DIFF
--- a/apps/redi-connect/src/components/organisms/modules/MSessions.tsx
+++ b/apps/redi-connect/src/components/organisms/modules/MSessions.tsx
@@ -138,11 +138,13 @@ const MSessions = ({ sessions, menteeId, editable }: MSessions) => {
 
       {editable && (
         <Modal
+          styles={{ overflow: 'unset' }} // This is needed to be able to show the datepicker outside the modal
           show={showAddSession}
           stateFn={setShowAddSession}
           title="Log a new mentoring session"
         >
-          <Modal.Body>
+          {/** overflow: 'unset' is needed to be able to show the datepicker outside the modal */}
+          <Modal.Body style={{ overflow: 'unset' }}>
             {/* <Content>Please write a few words about why you feel uncertain about your mentorship and which issues you are experiencing? </Content> */}
             <form>
               {createSessionMutation.isError ? (
@@ -150,6 +152,7 @@ const MSessions = ({ sessions, menteeId, editable }: MSessions) => {
               ) : null}
 
               <FormDatePicker
+                maxDate={new Date()}
                 label="When did the mentoring session take place?"
                 name="date"
                 placeholder="Add the correct date"

--- a/apps/redi-connect/src/components/organisms/modules/MSessions.tsx
+++ b/apps/redi-connect/src/components/organisms/modules/MSessions.tsx
@@ -52,7 +52,7 @@ const initialFormValues: FormValues = {
 }
 
 const validationSchema = Yup.object({
-  date: Yup.date().required().label('Date'),
+  date: Yup.date().max(new Date()).required().label('Date'),
   minuteDuration: Yup.string()
     .required('Please select the duration of the session.')
     .oneOf(
@@ -169,7 +169,7 @@ const MSessions = ({ sessions, menteeId, editable }: MSessions) => {
           <Modal.Foot>
             <Button
               onClick={() => formik.handleSubmit()}
-              disabled={!(formik.dirty && formik.isValid)}
+              disabled={!formik.isValid}
             >
               Add Session
             </Button>


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#624 
## What should the reviewer know?

 This PR disables selecting dates in the future, additionally it ensures the default date in the calendar is always set to today and that default values can be submitted.
