### PR TITLE
bugfix(con): fix userType check not working in SignUpComplete, conditionally render the Calendly link for mentees

### DIFF
--- a/apps/redi-connect/src/pages/front/signup/SignUp.tsx
+++ b/apps/redi-connect/src/pages/front/signup/SignUp.tsx
@@ -25,6 +25,7 @@ import { toPascalCaseAndTrim } from '@talent-connect/shared-utils'
 import { signUpLoopback } from '../../../services/api/api'
 import { history } from '../../../services/history/history'
 import { envRediLocation } from '../../../utils/env-redi-location'
+import { SignUpPageType } from './signup-page.type'
 
 export const validationSchema = Yup.object({
   firstName: Yup.string()
@@ -51,10 +52,6 @@ export const validationSchema = Yup.object({
   gaveGdprConsent: Yup.boolean().required().oneOf([true]),
 })
 
-type SignUpPageType = {
-  type: 'mentor' | 'mentee'
-}
-
 export interface SignUpFormValues {
   userType: UserType
   gaveGdprConsent: boolean
@@ -68,7 +65,7 @@ export interface SignUpFormValues {
 
 export default function SignUp() {
   const signUpMutation = useConProfileSignUpMutation()
-  const { type } = useParams<SignUpPageType>()
+  const { type } = useParams() as unknown as { type: SignUpPageType }
 
   const initialValues: SignUpFormValues = {
     userType: type.toUpperCase() as UserType,

--- a/apps/redi-connect/src/pages/front/signup/SignUpComplete.tsx
+++ b/apps/redi-connect/src/pages/front/signup/SignUpComplete.tsx
@@ -1,12 +1,13 @@
-import { UserType } from '@talent-connect/data-access'
+import { RediLocation, UserType } from '@talent-connect/data-access'
 import {
   Button,
-  Heading
+  Heading,
 } from '@talent-connect/shared-atomic-design-components'
 import { Columns, Content, Form } from 'react-bulma-components'
 import { useHistory, useParams } from 'react-router-dom'
 import { Teaser } from '../../../components/molecules'
 import AccountOperation from '../../../components/templates/AccountOperation'
+import { envRediLocation } from '../../../utils/env-redi-location'
 
 type RouteParams = {
   userType: UserType
@@ -15,6 +16,7 @@ type RouteParams = {
 export default function SignUpComplete() {
   const history = useHistory()
   const { userType } = useParams<RouteParams>() as RouteParams
+  const rediLocation = envRediLocation() as RediLocation
 
   return (
     <AccountOperation>
@@ -29,9 +31,9 @@ export default function SignUpComplete() {
           <Heading border="bottomLeft">Meet the team</Heading>
           <Content size="large" renderAs="div">
             <p>Thank you for signing up!</p>
-            {userType === UserType.Mentor && (
+            {userType.toUpperCase() === UserType.Mentor && (
               <>
-                <p>
+                <p style={{ textAlign: 'justify' }}>
                   Now, we would like to get to know you better. We regularly
                   organize mentor onboardings in small groups.{' '}
                   <a href="https://calendly.com/hadeertalentsucess/mentors-onboarding-session">
@@ -47,9 +49,9 @@ export default function SignUpComplete() {
                 </p>
               </>
             )}
-            {userType === UserType.Mentee && (
+            {userType.toUpperCase() === UserType.Mentee && (
               <>
-                <p>
+                <p style={{ textAlign: 'justify' }}>
                   Your next step is to watch a short onboarding tutorial to get
                   a good overview of the mentorship program and how our matching
                   platform ReDI Connect works.
@@ -68,17 +70,19 @@ export default function SignUpComplete() {
                   </a>
                 </p>
 
-                <p>
+                <p style={{ textAlign: 'justify' }}>
                   Your <strong>final step</strong> after watching this video
-                  will be your activation call with our team.
-                </p>
-                <p>
+                  will be your activation call with our team -{' '}
                   <a
-                    href="https://calendly.com/hadeertalentsucess/redi-connect-mentees-activation-call"
+                    href={
+                      rediLocation === 'CYBERSPACE'
+                        ? 'https://calendly.com/josefa_cyberspace/redi-connect-mentees-activation-call-cyberspace-only'
+                        : 'https://calendly.com/hadeertalentsucess/redi-connect-mentees-activation-call'
+                    }
                     target="_blank"
                     rel="noreferrer"
                   >
-                    Schedule your activation call now
+                    schedule your activation call now
                   </a>
                   .
                 </p>

--- a/apps/redi-connect/src/pages/front/signup/SignUpComplete.tsx
+++ b/apps/redi-connect/src/pages/front/signup/SignUpComplete.tsx
@@ -1,4 +1,4 @@
-import { RediLocation, UserType } from '@talent-connect/data-access'
+import { RediLocation } from '@talent-connect/data-access'
 import {
   Button,
   Heading,
@@ -8,15 +8,12 @@ import { useHistory, useParams } from 'react-router-dom'
 import { Teaser } from '../../../components/molecules'
 import AccountOperation from '../../../components/templates/AccountOperation'
 import { envRediLocation } from '../../../utils/env-redi-location'
-
-type RouteParams = {
-  userType: UserType
-}
+import { SignUpPageType, SignUpPageTypes } from './signup-page.type'
 
 export default function SignUpComplete() {
   const history = useHistory()
-  const { userType } = useParams<RouteParams>() as RouteParams
   const rediLocation = envRediLocation() as RediLocation
+  const { type } = useParams() as unknown as { type: SignUpPageType }
 
   return (
     <AccountOperation>
@@ -31,7 +28,7 @@ export default function SignUpComplete() {
           <Heading border="bottomLeft">Meet the team</Heading>
           <Content size="large" renderAs="div">
             <p>Thank you for signing up!</p>
-            {userType.toUpperCase() === UserType.Mentor && (
+            {type === SignUpPageTypes.mentor && (
               <>
                 <p style={{ textAlign: 'justify' }}>
                   Now, we would like to get to know you better. We regularly
@@ -49,7 +46,7 @@ export default function SignUpComplete() {
                 </p>
               </>
             )}
-            {userType.toUpperCase() === UserType.Mentee && (
+            {type === SignUpPageTypes.mentee && (
               <>
                 <p style={{ textAlign: 'justify' }}>
                   Your next step is to watch a short onboarding tutorial to get

--- a/apps/redi-connect/src/pages/front/signup/SignUpComplete.tsx
+++ b/apps/redi-connect/src/pages/front/signup/SignUpComplete.tsx
@@ -13,7 +13,7 @@ import { SignUpPageType, SignUpPageTypes } from './signup-page.type'
 export default function SignUpComplete() {
   const history = useHistory()
   const rediLocation = envRediLocation() as RediLocation
-  const { type } = useParams() as unknown as { type: SignUpPageType }
+  const { userType } = useParams() as unknown as { userType: SignUpPageType }
 
   return (
     <AccountOperation>
@@ -28,7 +28,7 @@ export default function SignUpComplete() {
           <Heading border="bottomLeft">Meet the team</Heading>
           <Content size="large" renderAs="div">
             <p>Thank you for signing up!</p>
-            {type === SignUpPageTypes.mentor && (
+            {userType === SignUpPageTypes.mentor && (
               <>
                 <p style={{ textAlign: 'justify' }}>
                   Now, we would like to get to know you better. We regularly
@@ -46,7 +46,7 @@ export default function SignUpComplete() {
                 </p>
               </>
             )}
-            {type === SignUpPageTypes.mentee && (
+            {userType === SignUpPageTypes.mentee && (
               <>
                 <p style={{ textAlign: 'justify' }}>
                   Your next step is to watch a short onboarding tutorial to get

--- a/apps/redi-connect/src/pages/front/signup/SignUpLanding.scss
+++ b/apps/redi-connect/src/pages/front/signup/SignUpLanding.scss
@@ -30,6 +30,7 @@
       text-align: center;
       line-height: 2rem;
       margin-top: 0.625rem;
+      text-transform: capitalize;
     }
   }
 }

--- a/apps/redi-connect/src/pages/front/signup/SignUpLanding.tsx
+++ b/apps/redi-connect/src/pages/front/signup/SignUpLanding.tsx
@@ -1,23 +1,24 @@
-import React, { useState } from 'react'
-import { useHistory } from 'react-router-dom'
-import { Content, Columns, Element } from 'react-bulma-components'
-import AccountOperation from '../../../components/templates/AccountOperation'
-import Teaser from '../../../components/molecules/Teaser'
 import {
   Button,
   Heading,
   SVGImage,
+  SVGImages,
 } from '@talent-connect/shared-atomic-design-components'
-import { SVGImages } from '@talent-connect/shared-atomic-design-components'
 import classnames from 'classnames'
+import { useState } from 'react'
+import { Columns, Content, Element } from 'react-bulma-components'
+import { useHistory } from 'react-router-dom'
+import Teaser from '../../../components/molecules/Teaser'
+import AccountOperation from '../../../components/templates/AccountOperation'
 import './SignUpLanding.scss'
+import { SignUpPageType } from './signup-page.type'
 
 const SignUpLanding = () => {
   const [selectedType, setSelectedType] = useState('')
   const history = useHistory()
 
-  const renderType = (name: string) => {
-    const type = name.toLowerCase() as SVGImages
+  const renderType = (pageType: SignUpPageType) => {
+    const type = pageType as SVGImages
 
     return (
       <div
@@ -29,7 +30,7 @@ const SignUpLanding = () => {
       >
         <SVGImage image={type} />
         <Element className="signup__type__name" renderAs="p">
-          {name}
+          {pageType}
         </Element>
       </div>
     )
@@ -52,8 +53,8 @@ const SignUpLanding = () => {
             <strong>mentee</strong>?
           </Content>
           <div className="signup">
-            {renderType('Mentee')}
-            {renderType('Mentor')}
+            {renderType('mentee')}
+            {renderType('mentor')}
           </div>
           <Button
             fullWidth

--- a/apps/redi-connect/src/pages/front/signup/signup-page.type.ts
+++ b/apps/redi-connect/src/pages/front/signup/signup-page.type.ts
@@ -1,0 +1,18 @@
+import { UserType } from '@talent-connect/data-access'
+
+type _UserType = typeof UserType
+type _UserTypeKey = keyof _UserType
+type _UserTypeValue = _UserType[_UserTypeKey]
+
+type UserTypePropertyLowercased = Lowercase<_UserTypeKey>
+type UserTypeValueLowercased = Lowercase<_UserTypeValue>
+
+export type SignUpPageTypes = Record<
+  UserTypePropertyLowercased,
+  UserTypeValueLowercased
+>
+export const SignUpPageTypes = {
+  [UserType.Mentor.toLowerCase()]: UserType.Mentor.toLowerCase(),
+  [UserType.Mentee.toLowerCase()]: UserType.Mentee.toLowerCase(),
+} as SignUpPageTypes
+export type SignUpPageType = SignUpPageTypes[keyof SignUpPageTypes]


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

There was a bug on the `Signup complete` page. The mentees and mentors did not see the information related to their type of user.

Signup complete page for mentees:
![image (1)](https://github.com/talent-connect/connect/assets/51786805/f79dc313-fe9d-4a1b-937b-f99721c1308c)

Signup complete page for mentors:
![image1](https://github.com/talent-connect/connect/assets/51786805/df71285a-4e67-4302-9323-53a85a8bc0fc)