### PR TITLE
chore(tp): hide job fair checkboxes from user profiles and filters

### DIFF
--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -267,8 +267,8 @@ export function BrowseCompany() {
             size="small"
           />
         </div>
-        {/* Hide after Job Fair */}
-        <div className="filters-inner">
+        {/* Hidden until the next Job Fair date announced */}
+        {/* <div className="filters-inner">
           <Checkbox
             name="joinsBerlin23SummerJobFair"
             checked={joinsBerlin23SummerJobFair || false}
@@ -285,7 +285,7 @@ export function BrowseCompany() {
           >
             ReDI Munich Summer Job Fair 2023
           </Checkbox>
-        </div>
+        </div> */}
       </div>
 
       <div className="active-filters">

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
@@ -271,9 +271,9 @@ export function BrowseJobseeker() {
         </div>
         <div className="filters-inner"></div>
       </div>
-      <div className="filters">
+      {/* Hidden until the next Job Fair date announced */}
+      {/* <div className="filters">
         <div className="filters-inner">
-          {/* Hide after Job Fair */}
           <Checkbox
             name="joinsBerlin23SummerJobFair"
             checked={joinsBerlin23SummerJobFair || false}
@@ -292,7 +292,7 @@ export function BrowseJobseeker() {
           </Checkbox>
         </div>
         <div className="filters-inner"></div>
-      </div>
+      </div> */}
 
       <div className="active-filters">
         {shouldShowFilters && (

--- a/apps/redi-talent-pool/src/pages/app/me/MeCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/MeCompany.tsx
@@ -97,8 +97,8 @@ export function MeCompany() {
       <Columns className="is-6 is-variable">
         <Columns.Column mobile={{ size: 12 }} tablet={{ size: 'three-fifths' }}>
           <EditableNamePhotoLocation companyProfile={companyProfile} />
-          {/* Hide after Job Fair */}
-          <div style={{ marginBottom: '1.5rem' }}>
+          {/* Hidden until the next Job Fair date announced */}
+          {/* <div style={{ marginBottom: '1.5rem' }}>
             <Checkbox
               checked={companyProfile.joinsBerlin23SummerJobFair}
               customOnChange={onBerlin23SummerJobFairParticipateChange}
@@ -113,7 +113,7 @@ export function MeCompany() {
               My company will attend <b>ReDI Summer Job Fair in Munich</b> on{' '}
               <b>10/07/2023</b>.
             </Checkbox>
-          </div>
+          </div> */}
           <EditableAbout companyProfile={companyProfile} />
         </Columns.Column>
         <Columns.Column mobile={{ size: 12 }} tablet={{ size: 'two-fifths' }}>

--- a/apps/redi-talent-pool/src/pages/app/me/MeJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/MeJobseeker.tsx
@@ -22,11 +22,11 @@ import { EditableOverview } from '../../../components/organisms/jobseeker-profil
 import { EditableProfessionalExperience } from '../../../components/organisms/jobseeker-profile-editables/EditableProfessionalExperience'
 import { EditableSummary } from '../../../components/organisms/jobseeker-profile-editables/EditableSummary'
 import { LoggedIn } from '../../../components/templates'
+import './MeJobseeker.scss'
 import { ReactComponent as ChecklistActiveImage } from './checklist-item-active.svg'
 import { ReactComponent as ChecklistImage } from './checklist-item.svg'
 import { ReactComponent as CheckmarkBorderOnlyImage } from './checkmark-border-only.svg'
 import { ReactComponent as CheckmarkImage } from './checkmark.svg'
-import './MeJobseeker.scss'
 import { ReactComponent as StepPendingImage } from './pending.svg'
 
 export function MeJobseeker() {
@@ -88,8 +88,8 @@ export function MeJobseeker() {
             <OnboardingSteps />
           </div>
           <EditableNamePhotoLocation profile={profile} />
-          {/* Hide after Job Fair */}
-          <div style={{ marginBottom: '1.5rem' }}>
+          {/* Hidden until the next Job Fair date announced */}
+          {/* <div style={{ marginBottom: '1.5rem' }}>
             <Checkbox
               checked={profile?.joinsBerlin23SummerJobFair}
               customOnChange={onBerlin23SummerJobFairParticipateChange}
@@ -106,7 +106,7 @@ export function MeJobseeker() {
               I will attend <b>ReDI Summer Job Fair in Munich</b> on{' '}
               <b>10/07/2023</b>.
             </Checkbox>
-          </div>
+          </div> */}
           <EditableOverview profile={profile} />
           <EditableSummary profile={profile} />
           <EditableProfessionalExperience profile={profile} />


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

No need to have these checkboxes on Jobseeker/Company Profile pages and Browse pages until the next Job Fair.
