### PR TITLE
chore(con/tp): update wording in the sign up emails

### DIFF
--- a/apps/nestjs-api/src/assets/email/templates/footer.career.support.team-tp.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/footer.career.support.team-tp.mjml
@@ -1,0 +1,49 @@
+<mjml>
+  <mj-include path="./head.mjml" />
+  <mj-body>
+    <mj-section css-class="section">
+      <mj-column mj-class="column" width="100%">
+        <mj-divider mj-class="divider-bottom" />
+        <mj-table padding="0">
+          <tr>
+            <td class="table-cell table-img" rowspan="4">
+              <img
+                src="https://redi-connect-email-assets.s3.eu-west-1.amazonaws.com/redi-logo.jpeg"
+                width="52px"
+              />
+            </td>
+            <td class="table-cell table-headline td-mobile" colspan="1">
+              ReDI Talent Success & Career Support Team
+            </td>
+          </tr>
+
+          <tr>
+            <td class="table-cell td-mobile">
+              General -
+              <a href="mailto:career@redi-school.org" class="text-link"
+                >career@redi-school.org</a
+              >
+            </td>
+          </tr>
+          <tr>
+            <td class="table-cell td-mobile">
+              Talent Pool -
+              <a href="mailto:paulina@redi-school.org" class="text-link"
+            >paulina@redi-school.org</a
+          >
+              <br /><br />
+              ReDI School of Digital Integration<br />
+              Mehringdamm 55, 10961 Berlin<br />
+              <a
+                href="https://www.redi-school.org"
+                class="text-link"
+                target="_blank"
+                >www.redi-school.org</a
+              >
+            </td>
+          </tr></mj-table
+        >
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/apps/nestjs-api/src/assets/email/templates/reset-password.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/reset-password.mjml
@@ -39,7 +39,8 @@
               >${rediEmailAdress}</a
             >.</mj-text
           >
-          <mj-text mj-class="text">Your Career Support Team</mj-text>
+          <mj-text mj-class="text">Best,</mj-text>
+          <mj-text mj-class="text">ReDI Career Support Team</mj-text>
         </mj-column>
       </mj-section>
       <mj-section />

--- a/apps/nestjs-api/src/assets/email/templates/signup-complete-mentee-cyberspace.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/signup-complete-mentee-cyberspace.mjml
@@ -88,6 +88,8 @@
           <mj-text mj-class="text paragraph" 
             >We’re looking forward to getting to know you soon!
           </mj-text>
+          <mj-text mj-class="text paragraph">If you did not register for our platform, please let us know immediately by replying to this email.
+          </mj-text>
 
           <mj-text mj-class="text">All the best,</mj-text>
           <mj-text mj-class="text">Your ReDI Career Support Team</mj-text>

--- a/apps/nestjs-api/src/assets/email/templates/signup-complete-mentee.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/signup-complete-mentee.mjml
@@ -87,6 +87,8 @@
           <mj-text mj-class="text paragraph" 
             >We’re looking forward to getting to know you soon!
           </mj-text>
+          <mj-text mj-class="text paragraph">If you did not register for our platform, please let us know immediately by replying to this email.
+          </mj-text>
 
           <mj-text mj-class="text">All the best,</mj-text>
           <mj-text mj-class="text">Your ReDI Career Support Team</mj-text>

--- a/apps/nestjs-api/src/assets/email/templates/signup-complete-mentor.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/signup-complete-mentor.mjml
@@ -44,6 +44,8 @@
           <mj-text mj-class="text paragraph" 
             >We’re looking forward to getting to know you soon!</mj-text
           >
+          <mj-text mj-class="text paragraph">If you did not register for our platform, please let us know immediately by replying to this email.
+          </mj-text>
 
           <mj-text mj-class="text">All the best,</mj-text>
           <mj-text mj-class="text">Your ReDI Career Support Team</mj-text>

--- a/apps/nestjs-api/src/assets/email/tp-templates/jobseeker-profile-approved.mjml
+++ b/apps/nestjs-api/src/assets/email/tp-templates/jobseeker-profile-approved.mjml
@@ -14,42 +14,36 @@
             >Dear ${firstName},</mj-text
           >
 
-          <mj-text mj-class="text" padding="0 0 20px 0"
+          <mj-text mj-class="text paragraph"
             >Congratulations - your profile has been approved!</mj-text
           >
-          <mj-text mj-class="text" padding="0 0 20px 0"
+          <mj-text mj-class="text paragraph"
             >You are now ReDI to start browsing all the job openings companies
             are sharing with us here on our Talent Pool platform.</mj-text
           >
-          <mj-text mj-class="text" padding="0 0 20px 0"
-            >How to do this?</mj-text
+          <mj-text mj-class="text paragraph"
+            >How to do this? Just log back into
+             <a href="https://talent-pool.redi-school.org/front/login" class="text-link"
+              >Talent Pool</a>.</mj-text
           >
-          <mj-text mj-class="text" padding="0 0 20px 0"
-            >Just log back into Talent Pool:</mj-text
-          >
-          <mj-text mj-class="text" padding="0 0 20px 0"
-            ><a href="https://talent-pool.redi-school.org" class="text-link"
-              >https://talent-pool.redi-school.org</a
-            ></mj-text
-          >
-          <mj-text mj-class="text" padding="0 0 20px 0"
+          <mj-text mj-class="text paragraph"
             >The companies are also able to browse all jobseekers, see your
             profile and invite you to an interview, if you fit the requirements
             of any of their open positions.</mj-text
           >
 
-          <mj-text mj-class="text" padding="0 0 20px 0"
+          <mj-text mj-class="text paragraph"
             >Please let us know, if you get invited for an interview and of
             course if you get hired!</mj-text
           >
 
           <mj-text mj-class="text">Best wishes,</mj-text>
           <mj-text mj-class="text"
-            >Paulina and your Career Support Team</mj-text
+            >ReDI Talent Success & Career Support Team</mj-text
           >
         </mj-column>
       </mj-section>
-      <mj-include path="../templates/footer.berlin.paulina.mjml" />
+      <mj-include path="../templates/footer.career.support.team-tp.mjml" />
       <mj-section />
     </mj-wrapper>
   </mj-body>

--- a/apps/nestjs-api/src/assets/email/tp-templates/reset-password.mjml
+++ b/apps/nestjs-api/src/assets/email/tp-templates/reset-password.mjml
@@ -41,7 +41,8 @@
               >${rediEmailAdress}</a
             >.</mj-text
           >
-          <mj-text mj-class="text">Your Career Support Team</mj-text>
+          <mj-text mj-class="text">Best,</mj-text>
+          <mj-text mj-class="text">ReDI Talent Success & Career Support Team</mj-text>
         </mj-column>
       </mj-section>
       <mj-section />

--- a/apps/nestjs-api/src/assets/email/tp-templates/signup-complete-company--signup-type-existing-company.mjml
+++ b/apps/nestjs-api/src/assets/email/tp-templates/signup-complete-company--signup-type-existing-company.mjml
@@ -26,6 +26,8 @@
           <mj-text mj-class="text paragraph"
             >We are excited to have you on board!</mj-text
           >
+           <mj-text mj-class="text paragraph">If you did not register for our platform, please let us know immediately by replying to this email.
+          </mj-text>
           <mj-text mj-class="text">Best,</mj-text>
           <mj-text mj-class="text">Janis</mj-text>
         </mj-column>

--- a/apps/nestjs-api/src/assets/email/tp-templates/signup-complete-company--signup-type-new-company.mjml
+++ b/apps/nestjs-api/src/assets/email/tp-templates/signup-complete-company--signup-type-new-company.mjml
@@ -14,17 +14,23 @@
             >Thank you for signing up!</mj-text
           >
           <mj-text mj-class="text paragraph"
-            >Now, it's time to log into Talent Pool and complete your company
+            >Now, it's time to log into <a
+              href="https://talent-pool.redi-school.org/front/login"
+              class="text-link"
+              >Talent Pool</a
+            > and complete your company
             profile and add your job listings. You will be able to add your
             vacant tech-related job listings – whether they are apprenticeships,
             internships or regular positions.
           </mj-text>
-          <mj-text mj-class="text paragraph"
+          <mj-text mj-class="text paragraph">
             Once it's complete, please send it to me for review.
           </mj-text>
           <mj-text mj-class="text paragraph"
             >We are excited to have you on board!</mj-text
           >
+          <mj-text mj-class="text paragraph">If you did not register for our platform, please let us know immediately by replying to this email.
+          </mj-text>
           <mj-text mj-class="text">Best,</mj-text>
           <mj-text mj-class="text">Janis</mj-text>
         </mj-column>

--- a/apps/nestjs-api/src/assets/email/tp-templates/signup-complete-jobseeker.mjml
+++ b/apps/nestjs-api/src/assets/email/tp-templates/signup-complete-jobseeker.mjml
@@ -24,6 +24,8 @@
           <mj-text mj-class="text paragraph"
             >I am excited to get to know you soon!</mj-text
           >
+          <mj-text mj-class="text paragraph">If you did not register for our platform, please let us know immediately by replying to this email.
+          </mj-text>
           <mj-text mj-class="text">Best,</mj-text>
           <mj-text mj-class="text">Paulina</mj-text>
         </mj-column>

--- a/apps/nestjs-api/src/assets/email/tp-templates/signup-complete-jobseeker.mjml
+++ b/apps/nestjs-api/src/assets/email/tp-templates/signup-complete-jobseeker.mjml
@@ -19,18 +19,18 @@
               >Talent Pool</a
             >
             and work on your profile. Once it's complete, you will be able to
-            send it to me for review.
+            send it to us for review.
           </mj-text>
           <mj-text mj-class="text paragraph"
-            >I am excited to get to know you soon!</mj-text
+            >We are excited to get to know you soon!</mj-text
           >
           <mj-text mj-class="text paragraph">If you did not register for our platform, please let us know immediately by replying to this email.
           </mj-text>
           <mj-text mj-class="text">Best,</mj-text>
-          <mj-text mj-class="text">Paulina</mj-text>
+          <mj-text mj-class="text">ReDI Talent Success & Career Support Team</mj-text>
         </mj-column>
       </mj-section>
-      <mj-include path="../templates/footer.berlin.paulina.mjml" />
+      <mj-include path="../templates/footer.career.support.team-tp.mjml" />
       <mj-section />
     </mj-wrapper>
   </mj-body>


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

Paulina requested to replace her email footer to jobseekers with a Talent Success & Career Support Team footer and add one sentence to the sign-up emails.

<img width="655" alt="image" src="https://github.com/talent-connect/connect/assets/51786805/5b7793f9-5076-49f7-93c0-58d20e0f2b5e">
