### PR TITLE
bugfix(con): display mentors occupation in their profile

### DIFF
--- a/apps/redi-connect/src/pages/app/me/Me.tsx
+++ b/apps/redi-connect/src/pages/app/me/Me.tsx
@@ -125,6 +125,7 @@ function Me() {
         </Element>
       )}
 
+      {/* When ReDI course is re-implemented, remove userIsMentor condition from here & EditableOccupation component above */}
       {userIsMentor && (
         <Element className="block-separator">
           <Columns>

--- a/apps/redi-connect/src/pages/app/me/Me.tsx
+++ b/apps/redi-connect/src/pages/app/me/Me.tsx
@@ -125,13 +125,15 @@ function Me() {
         </Element>
       )}
 
-      {/* <Element className="block-separator">
-        <Columns>
-          <Columns.Column size={6}>
-            <EditableOccupation />
-          </Columns.Column>
-        </Columns>
-      </Element> */}
+      {userIsMentor && (
+        <Element className="block-separator">
+          <Columns>
+            <Columns.Column size={6}>
+              <EditableOccupation />
+            </Columns.Column>
+          </Columns>
+        </Element>
+      )}
     </LoggedIn>
   )
 }

--- a/apps/redi-connect/src/pages/app/profile/Profile.tsx
+++ b/apps/redi-connect/src/pages/app/profile/Profile.tsx
@@ -1,12 +1,12 @@
 import {
   MentorshipMatchStatus,
   useLoadMyProfileQuery,
-  UserType
+  UserType,
 } from '@talent-connect/data-access'
 import {
   Button,
   Heading,
-  Icon
+  Icon,
 } from '@talent-connect/shared-atomic-design-components'
 import { REDI_LOCATION_NAMES } from '@talent-connect/shared-config'
 import { Columns, Content, Element, Notification } from 'react-bulma-components'
@@ -18,12 +18,13 @@ import {
   ReadLanguages,
   ReadMentoringTopics,
   ReadOccupation,
-  ReadPersonalDetail, ReadSocialMedia
+  ReadPersonalDetail,
+  ReadSocialMedia,
 } from '../../../components/molecules'
 import {
   ApplyForMentor,
   Avatar,
-  ConfirmMentorship
+  ConfirmMentorship,
 } from '../../../components/organisms'
 import DeclineMentorshipButton from '../../../components/organisms/DeclineMentorshipButton'
 import { LoggedIn } from '../../../components/templates'
@@ -212,7 +213,8 @@ function Profile() {
           )}
 
           {profile.mentor_occupation && (
-          // || profile.mentee_occupationCategoryId) 
+            // When ReDI course is re-implemented, uncomment this & remove ReadOccupation component above
+            // || profile.mentee_occupationCategoryId)
             <Element className="block-separator">
               <Columns>
                 <Columns.Column>


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue. 

## What should the reviewer know?

When I commented out the Occupation section [here](apps/redi-connect/src/pages/app/me/Me.tsx), I verified only the mentee's `My Profile` page and didn't verify the mentor’s `My Profile` page. It turned out that the mentor's occupation was not displayed.

![image](https://github.com/talent-connect/connect/assets/51786805/effc4348-1505-4ea8-bcbe-ba214980fc9e)