### PR TITLE
[#791] Fix text not shown on buttons for some browsers

### DIFF
--- a/libs/shared-atomic-design-components/src/lib/atoms/Button.scss
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Button.scss
@@ -27,6 +27,7 @@
   @include mobile() {
     width: calc(100% - 0.5rem);
     justify-content: center;
+    color: $black;
 
     + .button-atom {
       margin-top: 1rem;


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#791

## What should the reviewer know?
I was not able to reproduce the issue exactly, as I could see the texts on my test devices (An iPhone and a ZTE Android device), however I was seeing the button text colors a bit differently so I decided to try tackling that.

## Screenshots
**Before:**
![image](https://github.com/talent-connect/connect/assets/6314657/ee2c0381-cc09-46d5-a110-565615f470a1)

**After:**
![image](https://github.com/talent-connect/connect/assets/6314657/4e2b8dbd-2288-4d44-8d74-345981d41e3c)

## Note
As I mentioned, this might require some back and forth with @astkhikatredi to make sure everything is fixed.