### PR TITLE
bugfix(con): display correct signup-complete page to mentors, partnership mentors …

### DIFF
--- a/apps/redi-connect/src/pages/front/signup/SignUpComplete.tsx
+++ b/apps/redi-connect/src/pages/front/signup/SignUpComplete.tsx
@@ -36,41 +36,42 @@ export default function SignUpComplete() {
         <Columns.Column size={5} offset={1}>
           <Heading border="bottomLeft">Sign-up complete!</Heading>
           <Content size="large" renderAs="div">
-            {userType === SignUpPageTypes.mentor && isPartnershipMentor ? (
-              <>
-                <p style={{ textAlign: 'justify' }}>
-                  Thank you for signing up!{' '}
-                </p>{' '}
-                <p>
-                  Please go to your account and{' '}
-                  <strong>complete your profile information</strong>.
-                </p>
-              </>
-            ) : (
-              <>
-                <p style={{ textAlign: 'justify' }}>
-                  Now, we would like to get to know you better.
-                </p>
-                <p style={{ textAlign: 'justify' }}>
-                  Your next step is to{' '}
-                  <a
-                    href="https://calendly.com/hadeertalentsucess/mentors-onboarding-session"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    schedule a quick onboarding session
-                  </a>
-                  . It's the final step before you can kick off your journey as
-                  a mentor!{' '}
-                </p>
-                <p style={{ textAlign: 'justify' }}>
-                  In the meantime, please go to your account and{' '}
-                  <strong>complete your profile information</strong>. This step
-                  is super important because it helps students get to know you
-                  better and understand how you can support them.
-                </p>
-              </>
-            )}
+            {userType === SignUpPageTypes.mentor &&
+              (isPartnershipMentor ? (
+                <>
+                  <p style={{ textAlign: 'justify' }}>
+                    Thank you for signing up!{' '}
+                  </p>
+                  <p>
+                    Please go to your account and{' '}
+                    <strong>complete your profile information</strong>.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p style={{ textAlign: 'justify' }}>
+                    Now, we would like to get to know you better.
+                  </p>
+                  <p style={{ textAlign: 'justify' }}>
+                    Your next step is to{' '}
+                    <a
+                      href="https://calendly.com/hadeertalentsucess/mentors-onboarding-session"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      schedule a quick onboarding session
+                    </a>
+                    . It's the final step before you can kick off your journey
+                    as a mentor!{' '}
+                  </p>
+                  <p style={{ textAlign: 'justify' }}>
+                    In the meantime, please go to your account and{' '}
+                    <strong>complete your profile information</strong>. This
+                    step is super important because it helps students get to
+                    know you better and understand how you can support them.
+                  </p>
+                </>
+              ))}
 
             {userType === SignUpPageTypes.mentee && (
               <>


### PR DESCRIPTION
…and mentees

## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

This PR fixes what content our three types of users see on the `signup-complete` page.

## Screenshots

`signup-complete` page for mentees:
![image](https://github.com/talent-connect/connect/assets/51786805/3821d758-1cb6-4824-9e5b-bd5cedc3066e)

`signup-complete` page for partnership mentors:
![image](https://github.com/talent-connect/connect/assets/51786805/57e5f652-006d-4d57-ab35-8b674daa3523)

`signup-complete` page for regular mentors:
![image](https://github.com/talent-connect/connect/assets/51786805/7aa711d7-6008-4e9f-b6a4-fb432eb04239)
