### PR TITLE
fix(con): fix buttons UI on location picker page

### DIFF
--- a/libs/shared-atomic-design-components/src/lib/atoms/Button.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/Button.tsx
@@ -75,6 +75,7 @@ const Button = ({
         style={style}
       >
         {children}
+        {!simple && <div className="button-after" />}
       </button>
     )
   }


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

This PR fixes the UI of buttons on the location picker page.

Previously:
<img width="915" alt="image" src="https://github.com/talent-connect/connect/assets/51786805/c47970f7-12b7-4351-9094-78b0c73e60dc">

Now:
<img width="915" alt="image" src="https://github.com/talent-connect/connect/assets/51786805/d7b02bb5-2013-497a-9ff4-e43f2cbefabb">
