### PR TITLE
updated all wording for mentees to activation call and session, and u…

### DIFF
--- a/apps/nestjs-api/src/assets/email/templates/signup-complete-mentor.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/signup-complete-mentor.mjml
@@ -15,11 +15,11 @@
             >Great news - you're officially signed up!</mj-text
           >
           <mj-text mj-class="text paragraph"
-            >Your next step is to <strong>schedule a quick onboarding session</strong>. During this session, you'll get 
-            to meet our Mentorship Program Manager and dive deeper into how our Mentorship Program works. 
+            >Your next step is to <strong>schedule a quick onboarding session</strong>. During this session, you'll get
+            to meet our Mentorship Program Manager and dive deeper into how our Mentorship Program works.
             It's the final step before you can kick off your journey as a <strong>mentor</strong>!
           </mj-text>
-          
+
           <mj-image
             src="https://redi-connect-email-assets.s3-eu-west-1.amazonaws.com/schedule-meeting-large.png"
             align="center"
@@ -37,19 +37,19 @@
             css-class="button-mobile"
             href="https://calendly.com/hadeertalentsucess/mentors-onboarding-session"
           />
-          
-          <mj-text mj-class="text paragraph" 
+
+          <mj-text mj-class="text paragraph"
             >While you're at it, please take a moment to <a
               href="https://connect.redi-school.org/"
               class="text-link"
-              >log into your account</a> and <strong>fill out your profile</strong>. 
-            This step is super important because it helps students get to know you better and understand 
+              >log into your account</a> and <strong>fill out your profile</strong>.
+            This step is super important because it helps students get to know you better and understand
             how you can support them.</mj-text>
 
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >We can't wait to get to know you better and welcome you into our community!</mj-text
           >
-          
+
           <mj-text mj-class="text">All the best,</mj-text>
           <mj-text mj-class="text">Your ReDI Career Support Team</mj-text>
         </mj-column>

--- a/apps/nestjs-api/src/assets/email/templates/welcome-to-redi-mentee.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/welcome-to-redi-mentee.mjml
@@ -11,25 +11,25 @@
           <mj-text mj-class="text" padding="0 0 20px 0"
             >Hi ${firstName},</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >We are happy to now officially welcome you as a mentee to ReDI
             Connect!</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >Thank you again for having made the time today to meet for your
-            onboarding session during which we activated your profile.</mj-text
+            activation session during which we activated your profile.</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >What are your next steps?</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >If you haven't filled in your profile with the relevant information
             about yourself yet, please do so now. This way your potential future
             mentor can directly see who you are and what you’re looking for.
             Once you have completed your profile, you’re all set to start your
             mentor search!</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >To log in to your profile, you can click here:</mj-text
           >
           <mj-image
@@ -49,10 +49,10 @@
             css-class="button-mobile"
             href="${homePageUrl}"
           />
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >We wish you a wonderful mentorship experience!</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >If you have any questions or feedback at any point, please reach
             out!</mj-text
           >

--- a/apps/redi-connect/src/assets/locales/en/translation.json
+++ b/apps/redi-connect/src/assets/locales/en/translation.json
@@ -186,7 +186,7 @@
     "profile": {
       "notification": {
         "pendingMentor": "<strong>Thanks for signing up!</strong> We are reviewing your profile and will send you an email once we're done. Students will be able to apply to become your mentee once your account is active.",
-        "pendingMentee": "<strong>Thanks for signing up!</strong> Please schedule a time for an onboarding session with us. You find the link in the email you received. You’ll be able to find a mentor once your account is active.",
+        "pendingMentee": "<strong>Thanks for signing up!</strong> Please schedule a time for an activation session with us. You find the link in the email you received. You’ll be able to find a mentor once your account is active.",
         "deactivatedMentee": "Dear {{ name }}, your ReDI Connect profile has been deactivated by the Career Support Team. This could be for a number of reasons. If you think this has been done by mistake, please contact Paulina at {{ email }}. Thank you!",
         "deactivatedMentor": "Dear {{ name }}, your ReDI Connect profile has been deactivated by the Career Support Team. Likely you have not been active for a while. This means you are not visible to prospective mentees. If you want to become active as a mentor again, please contact {{ email }}. Speak soon!"
       }

--- a/apps/redi-connect/src/pages/front/signup/SignUpComplete.tsx
+++ b/apps/redi-connect/src/pages/front/signup/SignUpComplete.tsx
@@ -59,7 +59,7 @@ export default function SignUpComplete() {
                       target="_blank"
                       rel="noreferrer"
                     >
-                      schedule a quick onboarding session
+                      schedule a quick
                     </a>
                     . It's the final step before you can kick off your journey
                     as a mentor!{' '}


### PR DESCRIPTION
…pdated all wording for mentors to onboarding call and session

## What Github issue does this PR relate to? Insert link.
https://github.com/talent-connect/connect/issues/774
## What should the reviewer know?
I made all of the requested changes 
Mentees - all using "activation call" or "activation session" where applicable
Mentors - all using "onboarding call" or "onboarding session" where applicable

Screenshots
MENTEE SIGNUP:
![Con - profile page - mentee](https://github.com/talent-connect/connect/assets/104879063/f523654b-d61a-4ca9-a293-17715e0a1592)

MENTEE PROFILE:
![Con - signup page - mentee](https://github.com/talent-connect/connect/assets/104879063/0c49e8b8-5f11-40f0-afee-2794cd4243d0)

MENTOR SIGNUP:
![Con - signup page - mentor](https://github.com/talent-connect/connect/assets/104879063/68e1f11f-5281-4e9c-a24c-7dd9ec62b400)
