### PR TITLE
added padding to text, and adjusted illustration size

### DIFF
--- a/apps/nestjs-api/src/assets/email/templates/welcome-to-redi-mentee.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/welcome-to-redi-mentee.mjml
@@ -11,25 +11,25 @@
           <mj-text mj-class="text" padding="0 0 20px 0"
             >Hi ${firstName},</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >We are happy to now officially welcome you as a mentee to ReDI
             Connect!</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >Thank you again for having made the time today to meet for your
-            onboarding session during which we activated your profile.</mj-text
+            activation session during which we activated your profile.</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >What are your next steps?</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >If you haven't filled in your profile with the relevant information
             about yourself yet, please do so now. This way your potential future
             mentor can directly see who you are and what you’re looking for.
             Once you have completed your profile, you’re all set to start your
             mentor search!</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >To log in to your profile, you can click here:</mj-text
           >
           <mj-image
@@ -49,10 +49,10 @@
             css-class="button-mobile"
             href="${homePageUrl}"
           />
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >We wish you a wonderful mentorship experience!</mj-text
           >
-          <mj-text mj-class="text paragraph" 
+          <mj-text mj-class="text paragraph"
             >If you have any questions or feedback at any point, please reach
             out!</mj-text
           >

--- a/apps/redi-connect/src/assets/locales/en/translation.json
+++ b/apps/redi-connect/src/assets/locales/en/translation.json
@@ -186,7 +186,7 @@
     "profile": {
       "notification": {
         "pendingMentor": "<strong>Thanks for signing up!</strong> We are reviewing your profile and will send you an email once we're done. Students will be able to apply to become your mentee once your account is active.",
-        "pendingMentee": "<strong>Thanks for signing up!</strong> Please schedule a time for an onboarding session with us. You find the link in the email you received. You’ll be able to find a mentor once your account is active.",
+        "pendingMentee": "<strong>Thanks for signing up!</strong> Please schedule a time for an activation session with us. You find the link in the email you received. You’ll be able to find a mentor once your account is active.",
         "deactivatedMentee": "Dear {{ name }}, your ReDI Connect profile has been deactivated by the Career Support Team. This could be for a number of reasons. If you think this has been done by mistake, please contact Paulina at {{ email }}. Thank you!",
         "deactivatedMentor": "Dear {{ name }}, your ReDI Connect profile has been deactivated by the Career Support Team. Likely you have not been active for a while. This means you are not visible to prospective mentees. If you want to become active as a mentor again, please contact {{ email }}. Speak soon!"
       }

--- a/apps/redi-connect/src/components/organisms/RediHeroLanding.scss
+++ b/apps/redi-connect/src/components/organisms/RediHeroLanding.scss
@@ -56,12 +56,20 @@
     @include desktop() {
       margin: 0 auto;
       max-width: 70%;
+      padding-bottom: 1.5rem;
     }
+    @include mobile() {
+      padding-bottom: 1.5rem;
+    }
+    @include tablet() {
+      padding-bottom: 1.5rem;
+      }
   }
 
   &__illustration {
     @include desktop() {
       position: absolute;
+      max-height: 15rem;
 
       &--mentor {
         right: -5rem;


### PR DESCRIPTION

## What Github issue does this PR relate to? Insert link.
Fixing a UI bug on the mentors/mentees landing page #813
https://github.com/talent-connect/connect/issues/813

## What should the reviewer know?
I adjusted the padding bottom for text, including mobile, tablet, and desktop
I adjusted the size of the illustration - desktop only (I left some overlap of the illustration as I thought that was part of the design. I only changed it so that it didn't overlap with other icons/text.)


Screenshots below - landing page "Become a mentor/mentee"
![con-mentee-desktop](https://github.com/talent-connect/connect/assets/104879063/3857fca3-0527-4be6-a793-a46fc95cb678)
![con-mentee-mobile](https://github.com/talent-connect/connect/assets/104879063/605be331-9f66-419c-848d-11fcf2159c40)
![con-mentor-desktop](https://github.com/talent-connect/connect/assets/104879063/b0b0f574-c1a5-41e1-bc86-70277e5fe508)
![con-mentor-mobile](https://github.com/talent-connect/connect/assets/104879063/1a39347d-37bb-4a9f-bd1b-5b47658f842c)
