### PR TITLE
changed guidelines to guidance in CON FAQ

### DIFF
--- a/apps/redi-connect/src/assets/locales/en/translation.json
+++ b/apps/redi-connect/src/assets/locales/en/translation.json
@@ -81,7 +81,7 @@
         ]
       },
       {
-        "title": "Guidelines for Mentors",
+        "title": "Guidance for Mentors",
         "qAndAs": [
           {
             "question": "Who can become a mentor?",
@@ -118,7 +118,7 @@
         ]
       },
       {
-        "title": "Guidelines for Mentees",
+        "title": "Guidance for Mentees",
         "qAndAs": [
           {
             "question": "Why could I need a mentor?",


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
related to #793 
## What should the reviewer know?
@astkhikatredi asked me to change all mention of "guidelines" to "guidance" in CON FAQ

Screenshot
![CON - FAQ - guidance](https://github.com/talent-connect/connect/assets/104879063/0900f112-0b4d-4a24-853a-adc3f95eba8b)
