### PR TITLE
feat(con/tp): direct to intended page after login

### DIFF
--- a/apps/redi-connect/src/hooks/useNotAuthenticatedRedirector.ts
+++ b/apps/redi-connect/src/hooks/useNotAuthenticatedRedirector.ts
@@ -3,7 +3,18 @@ import { history } from '../services/history/history'
 
 export const useNotAuthenticatedRedirector = () => {
   if (!isLoggedIn()) {
-    history.replace('/front/login')
+    // For some reason code execution reaches this if branch
+    // even when .pathname is /front/login, which defeats the
+    // purpose of using history.location.pathname. We therefore
+    // only do a history.replace if the pathname starts with
+    // /app, meaning access to the authenticated/"private"
+    // part of the app.
+    const pathnameIsInPrivateArea = history.location.pathname.startsWith('/app')
+    if (pathnameIsInPrivateArea) {
+      history.replace(
+        `/front/login?goto=${encodeURIComponent(history.location.pathname)}`
+      )
+    }
     return { isRedirectingToLogin: true }
   }
   return { isRedirectingToLogin: false }

--- a/apps/redi-connect/src/pages/front/login/Login.tsx
+++ b/apps/redi-connect/src/pages/front/login/Login.tsx
@@ -122,7 +122,9 @@ export default function Login() {
         return
       }
 
-      return history.push('/app/me')
+      const urlParams = new URLSearchParams(window.location.search)
+      const goto = urlParams.get('goto') ?? '/app/me'
+      return history.push(goto)
     } catch (err) {
       // Do nothing
     }

--- a/apps/redi-talent-pool/src/hooks/useNotAuthenticatedRedirector.ts
+++ b/apps/redi-talent-pool/src/hooks/useNotAuthenticatedRedirector.ts
@@ -3,7 +3,18 @@ import { history } from '../services/history/history'
 
 export const useNotAuthenticatedRedirector = () => {
   if (!isLoggedIn()) {
-    history.replace('/front/login')
+    // For some reason code execution reaches this if branch
+    // even when .pathname is /front/login, which defeats the
+    // purpose of using history.location.pathname. We therefore
+    // only do a history.replace if the pathname starts with
+    // /app, meaning access to the authenticated/"private"
+    // part of the app.
+    const pathnameIsInPrivateArea = history.location.pathname.startsWith('/app')
+    if (pathnameIsInPrivateArea) {
+      history.replace(
+        `/front/login?goto=${encodeURIComponent(history.location.pathname)}`
+      )
+    }
     return { isRedirectingToLogin: true }
   }
   return { isRedirectingToLogin: false }

--- a/apps/redi-talent-pool/src/pages/front/login/Login.tsx
+++ b/apps/redi-talent-pool/src/pages/front/login/Login.tsx
@@ -219,7 +219,9 @@ class PostLoginSuccessHandler {
       return history.push('/front/signup-complete')
     }
     if (userHasATpProfile) {
-      return history.push('/app/me')
+      const urlParams = new URLSearchParams(window.location.search)
+      const goto = urlParams.get('goto') ?? '/app/me'
+      return history.push(goto)
     }
 
     throw new Error('User does not have a TP profile')


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

#824

## What should the reviewer know?

This PR ensures a user experiences when trying to access a CON/TP page requiring login but they aren't logged in:
1. Suppose user tries to access `/app/browse`, but isn't logged in
2. User redirected to `/front/login?goto=/app/browse` (the `/app/browse` is actually urlencoded so it actually becomes `%2Fapp%2Fbrowse`)
3. User logs in
4. Instead of being forwarded to the default path `/app/me`, user is sent to the "goto URL", i.e. `/app/browse`