### PR TITLE
bugfix(tp): recover styles for company profile stepper

### DIFF
--- a/apps/redi-talent-pool/src/pages/app/me/TpCompanyProfileOnboardingSteps.scss
+++ b/apps/redi-talent-pool/src/pages/app/me/TpCompanyProfileOnboardingSteps.scss
@@ -4,7 +4,7 @@
 $tp-light-blue: #58adc4;
 $tp-blue: #eff6f8;
 
-.onboarding-steps {
+.company-onboarding-steps {
   display: flex;
   flex-direction: column;
 

--- a/apps/redi-talent-pool/src/pages/app/me/TpCompanyProfileOnboardingSteps.scss
+++ b/apps/redi-talent-pool/src/pages/app/me/TpCompanyProfileOnboardingSteps.scss
@@ -1,0 +1,53 @@
+@import '_variables.scss';
+@import 'global.scss';
+
+$tp-light-blue: #58adc4;
+$tp-blue: #eff6f8;
+
+.onboarding-steps {
+  display: flex;
+  flex-direction: column;
+
+  padding: 0;
+
+  @include touch() {
+    margin-bottom: 1.5rem;
+  }
+  @include desktop() {
+    margin-bottom: 2.5rem;
+  }
+
+  border: 1px solid #d8d8d8;
+
+  &--header {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    height: 90px;
+  }
+
+  &--item {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+
+    padding: 18px 26px;
+    margin: 0;
+
+    div {
+      flex-grow: 1;
+    }
+
+    svg.checklist-image {
+      margin-right: 20px;
+    }
+  }
+  &--item.current-step {
+    background-color: $tp-blue;
+  }
+  &--item.completed-step {
+    color: $tp-light-blue;
+  }
+}

--- a/apps/redi-talent-pool/src/pages/app/me/TpCompanyProfileOnboardingSteps.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/TpCompanyProfileOnboardingSteps.tsx
@@ -9,7 +9,7 @@ import { ReactComponent as StepPendingImage } from '../../../assets/pending.svg'
 
 import { CompanyTalentPoolState } from '@talent-connect/data-access'
 import { TpCompanyProfileOnboardigStepsProfilePropFragment } from './TpCompanyProfileOnboardingSteps.generated'
-
+import './TpCompanyProfileOnboardingSteps.scss'
 const steps = [
   { number: 1, label: 'Complete your profile' },
   { number: 2, label: 'Post a job' },

--- a/apps/redi-talent-pool/src/pages/app/me/TpCompanyProfileOnboardingSteps.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/TpCompanyProfileOnboardingSteps.tsx
@@ -53,8 +53,8 @@ export function OnboardingSteps({
   )
 
   return (
-    <div className="onboarding-steps">
-      <div className="onboarding-steps--header">
+    <div className="company-onboarding-steps">
+      <div className="company-onboarding-steps--header">
         <Element
           renderAs="h4"
           textAlignment="centered"
@@ -68,7 +68,7 @@ export function OnboardingSteps({
       {steps.map((step, index) => (
         <div
           key={index}
-          className={classnames('onboarding-steps--item', {
+          className={classnames('company-onboarding-steps--item', {
             'current-step': step.number === currentStep[0],
             'completed-step': step.number < currentStep[0],
           })}


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#842

## What should the reviewer know?

The company's stepper design has a UI bug, exhibiting issues such as a broken general layout, lack of borders, and misalignment of text and symbols. Please refer to the screenshots below for visual details.
<img width="814" alt="294929168-988ba4a9-5d52-4574-bd49-d46af976e642" src="https://github.com/talent-connect/connect/assets/62472348/c43d0311-e329-4486-851c-0d45650251af">


Previously the profile pages (`MeCompany.tsx` & `MeJobseeker.tsx`) had the same parent `redi-talent-pool/src/pages/app/me/Me.tsx.` Each page had an `OnboardingSteps` component, but only `MeJobseeker.tsx` had a style file `MeJobseeker.scss` imported to it. Since those styles were global and `MeCompany.tsx`&`MeJobseeker.tsx` shared the parent, the styles were also applied to `MeCompany.tsx `, that uses the same classnames.

Currently, the profile pages don’t share a parent anymore, because the jobseeker profile now has id based urls.  `MeJobseeker.tsx` became `JobseekerProfileForJobseekerEyes.tsx` and `MeJobseeker.scss`  became `JobseekerProfileForJobseekerEyes.scss` under  `redi-talent-pool/src/pages/app/jobseeker-profile`.

This PR solves the issue by creating dedicated styles for `TpCompanyProfileOnboardingSteps.tsx`, based on the original style from `JobseekerProfileForJobseekerEyes.scss`.

<img width="1158" alt="Screenshot 2024-01-09 at 15 13 34" src="https://github.com/talent-connect/connect/assets/62472348/cf5680b8-fe33-42d3-83c8-0e4ac5db97ee">




