### PR TITLE
fix(tp): adjustments to jobListingCard design

### DIFF
--- a/apps/redi-talent-pool/src/components/organisms/JobListingCard.scss
+++ b/apps/redi-talent-pool/src/components/organisms/JobListingCard.scss
@@ -179,6 +179,7 @@
     font-weight: 400;
     color: var(--grey, #a0a0a0);
     white-space: nowrap;
+    height: 16px;
 
     @include mobile() {
       margin-top: 16px;

--- a/apps/redi-talent-pool/src/components/organisms/JobListingCard.scss
+++ b/apps/redi-talent-pool/src/components/organisms/JobListingCard.scss
@@ -90,8 +90,8 @@
     font-style: normal;
     font-weight: 800;
     line-height: 150%;
-    margin-top: 4.5px;
-    margin-bottom: 4.5px;
+    margin-top: 2px;
+    margin-bottom: 8px;
 
     @include mobile() {
       color: var(--grey, #a0a0a0);
@@ -111,11 +111,17 @@
   &__location {
     &-container {
       display: flex;
-      margin-bottom: 34px;
+      margin-bottom: 33px;
+      height: 16px;
 
       @include mobile {
         margin-bottom: 16px;
       }
+    }
+
+    &-icon {
+      position: relative;
+      left: -3px;
     }
 
     &-text {


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#841

## What should the reviewer know?

To follow the [design](https://www.figma.com/file/COW83FbwUhEXsAQ88lIIW7/Job-Listings-Cards-Design-(Ticket-688)?node-id=119%3A2676&mode=dev) more closely, this PR adjusts the spacings between `JobTitle`, `CompanyName` and `Location`, aligns the `locationIcon` with the rest of the text, and reduces the space between the timestamp("x days ago") and the bottom limit of the card.

Previous implementation:
<img width="1267" alt="Screenshot 2024-01-12 at 11 25 41" src="https://github.com/talent-connect/connect/assets/62472348/6fddf4ce-9203-4444-9b35-f7068daa6320">

New Implementation:
<img width="1275" alt="Screenshot 2024-01-12 at 11 26 05" src="https://github.com/talent-connect/connect/assets/62472348/50f1e0f3-e77d-461e-b77b-53b1ce7fcdae">