### PR TITLE
feat: :sparkles: update footer and sender for tp emails

### DIFF
--- a/apps/nestjs-api/src/assets/email/templates/footer.janis.mjml
+++ b/apps/nestjs-api/src/assets/email/templates/footer.janis.mjml
@@ -16,17 +16,18 @@
 
       <tr>
         <td class="table-cell td-mobile">
-          Career Partnerships Manager<br/>
-          <a href="mailto:janis@redi-school.org" class="text-link">
-            janis@redi-school.org
+          Career Partnerships Manager<br />
+          <a href="mailto:partner@redi-school.org" class="text-link">
+            partner@redi-school.org
           </a>
-          <br/><br/>
+          <br /><br />
           ReDI School of Digital Integration<br />
           <a
             href="https://www.redi-school.org"
             class="text-link"
             target="_blank"
-            >www.redi-school.org</a>
+            >www.redi-school.org</a
+          >
         </td>
       </tr>
     </mj-table>

--- a/apps/nestjs-api/src/email/lib/email/email.js
+++ b/apps/nestjs-api/src/email/lib/email/email.js
@@ -54,14 +54,15 @@ export const sendEmailFactory = (to, subject, body, rediLocation) => {
     },
   })
 }
-export const sendMjmlEmailFactory = ({ to, subject, html }) => {
+export const sendMjmlEmailFactory = ({ sender, to, subject, html }) => {
   let toSanitized = isProductionOrDemonstration() ? to : ''
+
   if (process.env.NX_DEV_MODE_EMAIL_RECIPIENT) {
     toSanitized = process.env.NX_DEV_MODE_EMAIL_RECIPIENT
   }
-  let sender = 'career@redi-school.org'
+
   return sendMjmlEmail({
-    from: sender,
+    from: sender ?? 'career@redi-school.org',
     to: toSanitized,
     bcc: ['career@redi-school.org'],
     subject: buildSubjectLine(subject, process.env.NODE_ENV),

--- a/apps/nestjs-api/src/email/lib/email/tp-email.js
+++ b/apps/nestjs-api/src/email/lib/email/tp-email.js
@@ -1,14 +1,8 @@
 'use strict'
 
-const aws = require('aws-sdk')
-const Rx = require('rxjs')
 const mjml2html = require('mjml')
-const nodemailer = require('nodemailer')
 const fs = require('fs')
 const path = require('path')
-
-const { buildTpFrontendUrl } = require('../build-tp-frontend-url')
-const { buildBackendUrl } = require('../build-backend-url')
 
 const { sendMjmlEmailFactory } = require('./email')
 
@@ -70,6 +64,7 @@ export const sendTpCompanyProfileApprovedEmail = ({ recipient, firstName }) => {
     firstName
   )
   return sendMjmlEmailFactory({
+    sender: 'Janis Janowsky <partner@redi-school.org>',
     to: recipient,
     subject: 'Your company profile has been approved for Talent Pool',
     html: html,
@@ -85,6 +80,7 @@ export const sendCompanySignupForNewCompanyCompleteEmail = ({
     'signup-complete-company--signup-type-new-company'
   ).replace(/\${firstName}/g, firstName)
   return sendMjmlEmailFactory({
+    sender: 'Janis Janowsky <partner@redi-school.org>',
     to: recipient,
     subject: 'Sign-up complete!',
     html,
@@ -103,6 +99,7 @@ export const sendCompanySignupForExistingCompanyCompleteEmail = ({
     .replace(/\${firstName}/g, firstName)
     .replace(/\${companyName}/g, companyName)
   return sendMjmlEmailFactory({
+    sender: 'Janis Janowsky <partner@redi-school.org>',
     to: recipient,
     subject: 'Sign-up complete!',
     html,


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#821 

## What should the reviewer know?
This PR updates the footer in the emails that are sent to companies in TP:

* janis@redi... => partner@redi...
* Sender is now Janis Janowsky <partner@redi-school.org> instead of career@redi-school.org

![CleanShot 2024-01-17 at 18 26 08](https://github.com/talent-connect/connect/assets/6314657/69a846eb-80d1-4856-8a8e-b8398a2a1fbb)
