### PR TITLE
[#748] Assign TP Company SF Contact to Account

### DIFF
--- a/apps/nestjs-api/src/tp-company-profiles/use-cases/tp-company-profile-sign-up/tp-company-profile-sign-up.use-case.ts
+++ b/apps/nestjs-api/src/tp-company-profiles/use-cases/tp-company-profile-sign-up/tp-company-profile-sign-up.use-case.ts
@@ -23,12 +23,12 @@ export class TpCompanyProfileSignUpUseCase {
   constructor(
     private readonly mapper: TpCompanyProfileMapper,
     private readonly sfService: SfApiTpCompanyProfilesService,
-    private readonly tpCompanyProfileksService: TpCompanyProfilesService,
+    private readonly tpCompanyProfilesService: TpCompanyProfilesService,
     private readonly emailService: EmailService,
     private readonly sfApi: SfApiRepository
   ) {}
 
-  // TODO: use a mapper here for more elegnat conversion
+  // TODO: use a mapper here for more elegant conversion
 
   // TOOD: ugh, this whole TpCompanyProfile module, related Contact, Account
   // and AccountContact are all messy. I need to review all again, and cleanly model
@@ -88,7 +88,7 @@ export class TpCompanyProfileSignUpUseCase {
     if (
       operationType === TpCompanyProfileSignUpOperationType.EXISTING_COMPANY
     ) {
-      companyEntity = await this.tpCompanyProfileksService.findOneById(
+      companyEntity = await this.tpCompanyProfilesService.findOneById(
         companyIdOrName
       )
 
@@ -198,5 +198,14 @@ export class TpCompanyProfileSignUpUseCase {
         accountContactRecord.Id
       )
     }
+
+    /**
+     * Updating the contact's Account from Household account to the Company account
+     */
+    const contactRecordProps = new ContactRecordProps()
+    contactRecordProps.Id = currentUser.userId
+    contactRecordProps.AccountId = companyEntity.props.id
+
+    await this.sfService.updateContact(ContactRecord.create(contactRecordProps))
   }
 }

--- a/libs/common-types/src/lib/common-objects/contact/contact.record.ts
+++ b/libs/common-types/src/lib/common-objects/contact/contact.record.ts
@@ -36,6 +36,7 @@ export class ContactRecord extends Record<ContactRecordProps> {
       'CON_TP_Mailing_Address__c',
       'CreatedDate',
       'LastModifiedDate',
+      'AccountId',
     ],
   }
 }

--- a/libs/common-types/src/lib/common-objects/contact/contact.recordprops.ts
+++ b/libs/common-types/src/lib/common-objects/contact/contact.recordprops.ts
@@ -33,6 +33,8 @@ export class ContactRecordProps implements RecordProps {
   @Type(() => Date)
   LastModifiedDate: Date
 
+  AccountId?: string
+
   // Only computed fields below
   Name: string // full name
 


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#748 

## What should the reviewer know?
This PR adds an additional step in the tp company sign-up use case, to assign the TP Comp Rep contact to TP Comp account 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved code clarity in company profile sign-up process.
- **New Features**
	- Enhanced contact update functionality to support account type changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->