### PR TITLE
Log out non-approved TP users

### DIFF
--- a/apps/redi-talent-pool/src/pages/app/me/Me.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/Me.tsx
@@ -1,6 +1,7 @@
 import { useMyTpDataQuery } from '@talent-connect/data-access'
 import { Loader } from '@talent-connect/shared-atomic-design-components'
 import { Redirect, useHistory } from 'react-router-dom'
+import { logout } from '../../../services/api/api'
 import { MeCompany } from './MeCompany'
 
 function Me() {
@@ -26,6 +27,7 @@ function Me() {
     case 'PENDING':
     case 'REJECTED':
     case 'DEACTIVATED':
+      logout()
       history.push('/front/signup-email-verification-success')
     case 'APPROVED':
       return <MeCompany />


### PR DESCRIPTION
## Description
This PR forces non-approved TP accounts to logout when they try to visit their profiles.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented automatic logout and redirection for users with 'PENDING', 'REJECTED', or 'DEACTIVATED' status to enhance account security and user experience.
	- Users with 'APPROVED' status now have access to the `MeCompany` component, improving navigation and access to relevant features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->