### PR TITLE
feat: :sparkles: add navigating rejected & deactivated users to login error page

### DIFF
--- a/apps/redi-talent-pool/src/pages/app/me/Me.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/Me.tsx
@@ -24,9 +24,12 @@ function Me() {
 
   switch (companyRepresentativeRelationship?.status) {
     case 'PENDING':
+      history.push('/front/signup-complete')
+      break
     case 'REJECTED':
     case 'DEACTIVATED':
-      history.push('/front/signup-email-verification-success')
+      history.push('/front/login-error')
+      break
     case 'APPROVED':
       return <MeCompany />
   }

--- a/apps/redi-talent-pool/src/pages/app/me/Me.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/Me.tsx
@@ -28,7 +28,7 @@ function Me() {
       break
     case 'REJECTED':
     case 'DEACTIVATED':
-      history.push('/front/login-error')
+      history.push('/front/login-result')
       break
     case 'APPROVED':
       return <MeCompany />

--- a/apps/redi-talent-pool/src/pages/front/login/LoginError.tsx
+++ b/apps/redi-talent-pool/src/pages/front/login/LoginError.tsx
@@ -1,17 +1,14 @@
-import { RediLocation } from '@talent-connect/data-access'
 import {
   Button,
   Heading,
 } from '@talent-connect/shared-atomic-design-components'
 import { Columns, Content, Form } from 'react-bulma-components'
 import { useHistory } from 'react-router-dom'
-import { Teaser } from '../../../components/molecules'
-import AccountOperation from '../../../components/templates/AccountOperation'
-import { envRediLocation } from '../../../utils/env-redi-location'
+import { Teaser } from '../../../../../redi-connect/src/components/molecules'
+import AccountOperation from '../../../../../redi-connect/src/components/templates/AccountOperation'
 
-export default function SignUpEmailVerificationSuccess() {
+export default function LoginError() {
   const history = useHistory()
-  const rediLocation = envRediLocation() as RediLocation
 
   return (
     <AccountOperation>
@@ -23,16 +20,21 @@ export default function SignUpEmailVerificationSuccess() {
           <Teaser.IllustrationOnly />
         </Columns.Column>
         <Columns.Column size={5} offset={1}>
-          <Heading border="bottomLeft">Email verified!</Heading>
+          <Heading border="bottomLeft">Changes to Your Platform Access</Heading>
           <Content size="large" renderAs="div">
-            <p>Thank you for verifying your email!</p>
-            <p>Now, please log in.</p>
+            <p>
+              Oops! It seems like your access to the platform has changed. If
+              you believe this is a mistake or have any questions, please reach
+              out to Janis at{' '}
+              <a href="mailto:partner@redi-school.org">
+                partner@redi-school.org
+              </a>
+              . We're here to help!
+            </p>
           </Content>
           <Form.Field className="submit-spacer">
             <Form.Control>
-              <Button onClick={() => history.push('/front/login')}>
-                Log in
-              </Button>
+              <Button onClick={() => history.push('/')}>Go Back</Button>
             </Form.Control>
           </Form.Field>
         </Columns.Column>

--- a/apps/redi-talent-pool/src/routes/routes__logged-out.tsx
+++ b/apps/redi-talent-pool/src/routes/routes__logged-out.tsx
@@ -10,6 +10,12 @@ const Login = lazy(
       /* webpackChunkName: "Login", webpackPreload: true */ '../pages/front/login/Login'
     )
 )
+const LoginError = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "LoginError", webpackPreload: true */ '../pages/front/login/LoginError'
+    )
+)
 const SignUp = lazy(
   () =>
     import(
@@ -55,6 +61,11 @@ export const routes__loggedOut: RouteDefinition[] = [
   {
     path: '/front/login',
     component: Login,
+    exact: true,
+  },
+  {
+    path: '/front/login-error',
+    component: LoginError,
     exact: true,
   },
   {

--- a/apps/redi-talent-pool/src/routes/routes__logged-out.tsx
+++ b/apps/redi-talent-pool/src/routes/routes__logged-out.tsx
@@ -64,7 +64,7 @@ export const routes__loggedOut: RouteDefinition[] = [
     exact: true,
   },
   {
-    path: '/front/login-error',
+    path: '/front/login-result',
     component: LoginError,
     exact: true,
   },


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#800 

## What should the reviewer know?
This PR changes the behavior of redirecting PENDING, REJECTED and DEACTIVATED TP Company Representatives. Previously we were redirecting them to Signup Verification Success page, but with this PR, we are creating a new page for REJECTED and DEACTIVATED Reps and redirecting PENDING Reps to Signup Complete page. (Screenshots below)

## Open Questions
There are a few open questions that can change the implementation when answered:
* @ericbolikowski what do you feel about the `login-error` URL? It sounds very generic but it's actually only being used for TP Comp Reps. Any better ideas?

## Screenshots

**REJECTED/DEACTIVATED TP Comp Reps:**
![CleanShot 2024-02-12 at 23 29 55](https://github.com/talent-connect/connect/assets/6314657/9a88ef9e-7243-4d59-b0bf-bca8fd2af64a)

**PENDING TP Comp Reps:**
![CleanShot 2024-02-12 at 23 33 06](https://github.com/talent-connect/connect/assets/6314657/be654285-511f-4e05-8089-f67a07e369de)
