### PR TITLE
feat(con): add Swedish to mentoring topics list

### DIFF
--- a/libs/common-types/src/lib/con-profile/enums/mentoring-topic.enum.ts
+++ b/libs/common-types/src/lib/con-profile/enums/mentoring-topic.enum.ts
@@ -25,6 +25,7 @@ export enum MentoringTopic {
   'basicGerman' = 'basicGerman',
   'businessGerman' = 'businessGerman',
   'english' = 'english',
+  'swedish' = 'swedish',
   'graphicDesign' = 'graphicDesign',
   'userInterfaceDesign' = 'userInterfaceDesign',
   'userExperienceDesign' = 'userExperienceDesign',

--- a/libs/data-access/src/lib/types/types.ts
+++ b/libs/data-access/src/lib/types/types.ts
@@ -515,6 +515,7 @@ export enum MentoringTopic {
   React = 'react',
   Sales = 'sales',
   Salesforce = 'salesforce',
+  Swedish = 'swedish',
   UserExperienceDesign = 'userExperienceDesign',
   UserInterfaceDesign = 'userInterfaceDesign'
 }

--- a/libs/shared-config/src/lib/config.ts
+++ b/libs/shared-config/src/lib/config.ts
@@ -89,6 +89,7 @@ export const CATEGORIES = [
   { id: 'basicGerman', label: 'Basic German 🇩🇪', group: 'language' },
   { id: 'businessGerman', label: 'Business German 🇩🇪', group: 'language' },
   { id: 'english', label: 'English 🇬🇧', group: 'language' },
+  { id: 'swedish', label: 'Swedish 🇸🇪', group: 'language' },
   { id: 'graphicDesign', label: 'Graphic Design', group: 'design' },
   {
     id: 'userInterfaceDesign',

--- a/schema.graphql
+++ b/schema.graphql
@@ -493,6 +493,7 @@ enum MentoringTopic {
   react
   sales
   salesforce
+  swedish
   userExperienceDesign
   userInterfaceDesign
 }


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Closes #896 

## What should the reviewer know?

Salesforce changes:
- Added a new value `Swedish` to the mentoring topics list on `partial`, `contp` & `production` orgs

Codebase changes:
- Added a new value `Swedish` to the mentoring topics list 

## Screenshots

<img width="204" alt="image" src="https://github.com/talent-connect/connect/assets/51786805/3815f8c2-bbc3-497d-bdb0-fc705cacd094">

<img width="737" alt="image" src="https://github.com/talent-connect/connect/assets/51786805/c8229084-a482-4fee-bf64-617aade882a6">
