### PR TITLE
feat(tp): make company visible to jobseekers after its profile approval

### DIFF
--- a/apps/nestjs-api/src/tp-company-profiles/tp-company-profiles.service.ts
+++ b/apps/nestjs-api/src/tp-company-profiles/tp-company-profiles.service.ts
@@ -51,9 +51,7 @@ export class TpCompanyProfilesService {
       props[key] = value
     })
     const entityToPersist = TpCompanyProfileEntity.create(props)
-    await this.sfService.updateTpCompanyProfile(
-      this.mapper.toPersistence(entityToPersist)
-    )
+    await this.update(entityToPersist)
   }
 
   async update(entity: TpCompanyProfileEntity) {

--- a/apps/nestjs-api/src/tp-company-profiles/tp-company-profiles.service.ts
+++ b/apps/nestjs-api/src/tp-company-profiles/tp-company-profiles.service.ts
@@ -56,6 +56,12 @@ export class TpCompanyProfilesService {
     )
   }
 
+  async update(entity: TpCompanyProfileEntity) {
+    await this.sfService.updateTpCompanyProfile(
+      this.mapper.toPersistence(entity)
+    )
+  }
+
   // TODO: this same method exists in TpCompanyRepresentativesService.
   // We can't use that class as a dependency here because it would
   // create a circular dependency. Refactor to solve for that.

--- a/apps/redi-talent-pool/src/pages/app/me/MeCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/MeCompany.tsx
@@ -134,12 +134,14 @@ export function MeCompany() {
             companyProfile={companyProfile}
             userContact={userContact}
           />
-          <Checkbox
-            checked={!companyProfile.isProfileVisibleToJobseekers}
-            customOnChange={onHideFromJobseekersCheckboxChange}
-          >
-            Hide job listings from jobseekers
-          </Checkbox>
+          {isProfileApproved && (
+            <Checkbox
+              checked={!companyProfile.isProfileVisibleToJobseekers}
+              customOnChange={onHideFromJobseekersCheckboxChange}
+            >
+              Hide job listings from jobseekers
+            </Checkbox>
+          )}
         </Columns.Column>
       </Columns>
       <EditableJobPostings jobListings={activeJobListings} />

--- a/apps/redi-talent-pool/src/pages/front/signup/SignUp.tsx
+++ b/apps/redi-talent-pool/src/pages/front/signup/SignUp.tsx
@@ -202,10 +202,12 @@ export default function SignUp() {
 
         <Columns.Column size={5} offset={1}>
           <Heading border="bottomLeft">Sign-up</Heading>
-          <Content size="small" renderAs="p">
-            Got a ReDI Connect user account? You can log in with the same
-            username and password <Link to="/front/login">here</Link>.
-          </Content>
+          {type === 'jobseeker' && (
+            <Content size="small" renderAs="p">
+              Got a ReDI Connect user account? You can log in with the same
+              username and password <Link to="/front/login">here</Link>.
+            </Content>
+          )}
           {loopbackSubmitError === 'user-already-exists' && (
             <Notification color="info" className="is-light">
               You already have an account. Please{' '}

--- a/apps/redi-talent-pool/src/pages/front/signup/SignUp.tsx
+++ b/apps/redi-talent-pool/src/pages/front/signup/SignUp.tsx
@@ -11,7 +11,6 @@ import {
   Heading,
 } from '@talent-connect/shared-atomic-design-components'
 import { REDI_LOCATION_NAMES } from '@talent-connect/shared-config'
-import { TpCompanyProfile } from '@talent-connect/shared-types'
 import { toPascalCaseAndTrim } from '@talent-connect/shared-utils'
 import { howDidHearAboutRediOptions } from '@talent-connect/talent-pool/config'
 import { objectEntries } from '@talent-connect/typescript-utilities'
@@ -157,10 +156,6 @@ export default function SignUp() {
       }
 
       if (type === 'company') {
-        const transformedValues = buildValidationSchema('company').cast(values)
-        const profile = transformedValues as Partial<TpCompanyProfile>
-        profile.isProfileVisibleToJobseekers = true
-
         await signUpLoopback(values.email, values.password, {
           companyIdOrName: values.companyIdOrName,
           firstName: values.firstName,


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Closes #880.

## What should the reviewer know?

In this PR,  we make sure that:

-  the company (company's job listings) automatically becomes visible to jobseekers after its profile has been approved
-  the `isProfileVisibleToJobseekers` checkbox is hidden from the company representative profile view until the company profile is approved
- cross-login information for the company representative user was removed because it is intended for jobseekers only

## Screenshots

Drafting company profile:
![image](https://github.com/talent-connect/connect/assets/51786805/a85efac8-1294-4cf6-8ac3-a2799ef542de)

Approved company profile:
![image](https://github.com/talent-connect/connect/assets/51786805/ec3bf714-2bc7-431e-8233-309c3b3bab4e)

Signup page for companies:
<img width="901" alt="image" src="https://github.com/talent-connect/connect/assets/51786805/2a8f9d42-a5d7-4ca5-94d4-2e7e0bed5ca6">