### PR TITLE
fix(tp): 3-dots menu

### DIFF
--- a/apps/redi-talent-pool/src/components/organisms/JobListingCard.scss
+++ b/apps/redi-talent-pool/src/components/organisms/JobListingCard.scss
@@ -28,6 +28,8 @@
   }
 
   &__firstColumn {
+    display: flex;
+    justify-content: space-between;
     padding: 0;
     margin: 0;
     flex-shrink: 0;

--- a/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobListingCard.tsx
@@ -1,12 +1,13 @@
+import { useMediaQuery, useTheme } from '@mui/material'
 import { CardTags } from '@talent-connect/shared-atomic-design-components'
 import { topSkillsIdToLabelMap } from '@talent-connect/talent-pool/config'
 import React from 'react'
 import { Card } from 'react-bulma-components'
 import { NavLink } from 'react-router-dom'
+import CardLocation from '../../../../../libs/shared-atomic-design-components/src/lib/atoms/CardLocation'
 import placeholderImage from '../../assets/images/company-placeholder-img.svg'
 import './JobListingCard.scss'
 import { JobListingCardJobListingPropFragment } from './jobseeker-profile-editables/JobListingCard.generated'
-import CardLocation from '../../../../../libs/shared-atomic-design-components/src/lib/atoms/CardLocation'
 
 interface JobListingCardProps {
   jobListing: JobListingCardJobListingPropFragment
@@ -35,6 +36,10 @@ export function JobListingCard({
     profileAvatarImageS3Key: companyAvatarImage,
   } = jobListing
 
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down(769))
+  const isTabletOrDesktop = useMediaQuery(theme.breakpoints.up(769))
+
   const imgSrc = companyAvatarImage ? companyAvatarImage : placeholderImage
 
   const InnerCard = () => (
@@ -45,7 +50,10 @@ export function JobListingCard({
             className="job-posting-card__image"
             src={imgSrc}
             alt={jobTitle}
-          ></img>
+          />
+          <div style={{ height: '100%' }}>
+            {isMobile && renderCTA && renderCTA()}
+          </div>
         </div>
         <div className="job-posting-card__middleColumn">
           <p className="job-posting-card__job-title">{jobTitle}</p>
@@ -62,7 +70,7 @@ export function JobListingCard({
         </div>
         <div className="job-posting-card__lastColumn">
           <div className="job-posting-card__timeFooterBox">
-            {renderCTA && renderCTA()}
+            {isTabletOrDesktop && renderCTA && renderCTA()}
             {timestamp && (
               <div className="job-posting-card__timestamp">{timestamp}</div>
             )}

--- a/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/company-profile-editables/EditableJobPostings.tsx
@@ -27,7 +27,6 @@ import {
 
 import { CardContextMenu } from '../../../components/molecules/CardContextMenu'
 
-import { Tooltip } from '@mui/material'
 import { TALENT_POOL_URL } from '@talent-connect/shared-config'
 import { objectEntries } from '@talent-connect/typescript-utilities'
 import { formatDistance } from 'date-fns'
@@ -198,45 +197,36 @@ function JobListingCards({ jobListings, startEditing }) {
             jobListing={jobListing}
             timestamp={renderTimestamp(jobListing.expiresAt)}
             renderCTA={() => (
-              <Tooltip
-                title="You can copy the job posting link here"
-                placement="top"
-                arrow
+              <CardContextMenu
+                menuItems={[
+                  {
+                    label: 'Edit',
+                    onClick: () => startEditing(jobListing.id),
+                    icon: 'editLightGrey',
+                  },
+                  {
+                    label: 'Copy link',
+                    onClick: () => copyUrl(jobListing.id),
+                    icon: 'link',
+                  },
+                  {
+                    label: 'Delete',
+                    onClick: () =>
+                      setDeleteModalOpenForJobPostingId(jobListing.id),
+                    icon: 'delete',
+                  },
+                ]}
               >
-                {/* Acceptable hack: Tooltip doesn't trigger correctly unless child wrapped in <span> */}
-                <span>
-                  <CardContextMenu
-                    menuItems={[
-                      {
-                        label: 'Edit',
-                        onClick: () => startEditing(jobListing.id),
-                        icon: 'editLightGrey',
-                      },
-                      {
-                        label: 'Copy link',
-                        onClick: () => copyUrl(jobListing.id),
-                        icon: 'link',
-                      },
-                      {
-                        label: 'Delete',
-                        onClick: () =>
-                          setDeleteModalOpenForJobPostingId(jobListing.id),
-                        icon: 'delete',
-                      },
-                    ]}
-                  >
-                    <LightModal
-                      isOpen={deleteModalOpenForJobPostingId === jobListing.id}
-                      handleClose={handleDeleteModalClose}
-                      headline="Delete job posting?"
-                      message="You will lose all the information entered for this job posting."
-                      ctaLabel="Delete"
-                      ctaOnClick={() => handleDelete(jobListing.id)}
-                      cancelLabel="Keep it"
-                    />
-                  </CardContextMenu>
-                </span>
-              </Tooltip>
+                <LightModal
+                  isOpen={deleteModalOpenForJobPostingId === jobListing.id}
+                  handleClose={handleDeleteModalClose}
+                  headline="Delete job posting?"
+                  message="You will lose all the information entered for this job posting."
+                  ctaLabel="Delete"
+                  ctaOnClick={() => handleDelete(jobListing.id)}
+                  cancelLabel="Keep it"
+                />
+              </CardContextMenu>
             )}
           />
         </Columns.Column>

--- a/libs/shared-atomic-design-components/src/lib/molecules/NewProfileCard.tsx
+++ b/libs/shared-atomic-design-components/src/lib/molecules/NewProfileCard.tsx
@@ -1,10 +1,10 @@
-import './NewProfileCard.scss'
 import { CardTags, Icon } from '@talent-connect/shared-atomic-design-components'
 import React, { ReactNode } from 'react'
 import { Card, Tag } from 'react-bulma-components'
 import { NavLink } from 'react-router-dom'
-import LocationIcon from '../../assets/images/location.svg'
 import LanguagesIcon from '../../assets/images/globe.svg'
+import LocationIcon from '../../assets/images/location.svg'
+import './NewProfileCard.scss'
 
 interface NewProfileCardProps {
   profile: {
@@ -34,7 +34,7 @@ const UserLocation = ({ location }) => {
         alt="Location"
         className="new-profile-card__location-icon"
       />
-      <p className="new-profile-card__location-text">Based in {location}</p>
+      <p className="new-profile-card__location-text">ReDI {location}</p>
     </div>
   )
 }


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Closes #868 

## What should the reviewer know?

In this PR, we:
- Fix the position of the 3-dots menu in the mobile view
- Remove the tooltip from the 3-dots menu
- Update the location wording on the mentor card (CON)

## Screenshots

Job Listing card (mobile view):
![image](https://github.com/talent-connect/connect/assets/51786805/a0140b38-c0b2-4174-9799-729b3114bf0b)

![image](https://github.com/talent-connect/connect/assets/51786805/3a1246b5-c37d-44e0-9e0b-3339e55832aa)

Updated mentor card:
![image](https://github.com/talent-connect/connect/assets/51786805/770d017b-0314-48ff-93b2-59c5630b278c)