### PR TITLE
Feature/connect/display rejected status page #889

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,9 @@
       }
     ]
   },
-  "editor.codeActionsOnSave": { "source.organizeImports": true },
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit"
+  },
   "explorer.fileNesting.patterns": {
     "*.ts": "${capture}.js, ${capture}.typegen.ts, ${capture}.graphql, ${capture}.generated.ts",
     "*.js": "${capture}.js.map, ${capture}.min.js, ${capture}.d.ts",

--- a/apps/redi-connect/src/assets/locales/en/translation.json
+++ b/apps/redi-connect/src/assets/locales/en/translation.json
@@ -190,7 +190,9 @@
     "profile": {
       "notification": {
         "deactivatedMentee": "Dear {{ name }}, your ReDI Connect profile has been deactivated by the ReDI Talent Success Team. This could be for a number of reasons. If you think this has been done by mistake, please contact us at {{ email }}. Thank you!",
-        "deactivatedMentor": "Dear {{ name }}, your ReDI Connect profile has been deactivated by the ReDI Talent Success Team. Likely you have not been active for a while. This means you are not visible to prospective mentees. If you want to become active as a mentor again, please contact {{ email }}. Speak soon!"
+        "deactivatedMentor": "Dear {{ name }}, your ReDI Connect profile has been deactivated by the ReDI Talent Success Team. Likely you have not been active for a while. This means you are not visible to prospective mentees. If you want to become active as a mentor again, please contact {{ email }}. Speak soon!",
+        "rejectedMentee": "Dear {{ name }}, your ReDI Connect profile has been rejected by the ReDI Talent Success Team. This could be for a number of reasons. If you think this has been done by mistake, please contact us at {{ email }}. Thank you!",
+        "rejectedMentor": "Dear {{ name }}, your ReDI Connect profile has been rejected by the ReDI Talent Success Team. Likely you have not been active for a while. This means you are not visible to prospective mentees. If you want to become active as a mentor again, please contact {{ email }}. Speak soon!"
       }
     }
   },

--- a/apps/redi-connect/src/components/templates/LoggedIn.tsx
+++ b/apps/redi-connect/src/components/templates/LoggedIn.tsx
@@ -107,11 +107,31 @@ function LoggedIn({ children }: Props) {
                     })}
                   </RediNotification>
                 )}
+              {profile?.userType === 'MENTEE' &&
+                profile?.profileStatus === ConnectProfileStatus.Rejected && (
+                  <RediNotification>
+                    {t('loggedInArea.profile.notification.rejectedMentee', {
+                      name: profile.firstName,
+                      email:
+                        '<a href="mailto:career@redi-school.org">career@redi-school.org</a>',
+                    })}
+                  </RediNotification>
+                )}
               {profile?.userType === 'MENTOR' &&
                 profile?.profileStatus === ConnectProfileStatus.Deactivated && (
                   <RediNotification>
                     {t('loggedInArea.profile.notification.deactivatedMentor', {
                       name: profile?.firstName,
+                      email:
+                        '<a href="mailto:career@redi-school.org">career@redi-school.org</a>',
+                    })}
+                  </RediNotification>
+                )}
+              {profile?.userType === 'MENTOR' &&
+                profile?.profileStatus === ConnectProfileStatus.Rejected && (
+                  <RediNotification>
+                    {t('loggedInArea.profile.notification.rejectedMentor', {
+                      name: profile.firstName,
                       email:
                         '<a href="mailto:career@redi-school.org">career@redi-school.org</a>',
                     })}

--- a/apps/redi-connect/src/pages/app/me/Me.tsx
+++ b/apps/redi-connect/src/pages/app/me/Me.tsx
@@ -31,11 +31,13 @@ import {
 import { REDI_LOCATION_NAMES } from '@talent-connect/shared-config'
 import { useLoading } from '../../../hooks/WithLoading'
 // CHECK OUT THE LOADER
+import { useHistory } from 'react-router-dom'
 import './Me.scss'
 import OnboardingSteps from './OnboardingSteps'
 
 function Me() {
   const queryClient = useQueryClient()
+  const history = useHistory()
   const submitProfileForReviewMutation = useConProfileSubmitForReviewMutation()
   const { Loading, isLoading } = useLoading()
   const myProfileResult = useLoadMyProfileQuery(
@@ -50,6 +52,11 @@ function Me() {
   // that Eric has been looking into.
 
   const conProfile = myProfileResult?.data?.conProfile
+  // if (conProfile?.profileStatus === 'DEACTIVATED') {
+  //   // logout()
+  //   history.push('/front/login')
+  // }
+
   if (!conProfile) return <Loading />
 
   const {

--- a/apps/redi-connect/src/pages/app/me/Me.tsx
+++ b/apps/redi-connect/src/pages/app/me/Me.tsx
@@ -31,13 +31,11 @@ import {
 import { REDI_LOCATION_NAMES } from '@talent-connect/shared-config'
 import { useLoading } from '../../../hooks/WithLoading'
 // CHECK OUT THE LOADER
-import { useHistory } from 'react-router-dom'
 import './Me.scss'
 import OnboardingSteps from './OnboardingSteps'
 
 function Me() {
   const queryClient = useQueryClient()
-  const history = useHistory()
   const submitProfileForReviewMutation = useConProfileSubmitForReviewMutation()
   const { Loading, isLoading } = useLoading()
   const myProfileResult = useLoadMyProfileQuery(
@@ -52,11 +50,6 @@ function Me() {
   // that Eric has been looking into.
 
   const conProfile = myProfileResult?.data?.conProfile
-  // if (conProfile?.profileStatus === 'DEACTIVATED') {
-  //   // logout()
-  //   history.push('/front/login')
-  // }
-
   if (!conProfile) return <Loading />
 
   const {

--- a/apps/redi-connect/src/pages/front/login/Login.tsx
+++ b/apps/redi-connect/src/pages/front/login/Login.tsx
@@ -81,13 +81,17 @@ export default function Login() {
     try {
       // Load "outside" of react-query to avoid having to build
       // a complex logic adhering to the rules-of-hooks.
-      await fetcher<LoadMyProfileQuery, LoadMyProfileQueryVariables>(
-        LoadMyProfileDocument,
-        {
-          loopbackUserId: getAccessTokenFromLocalStorage().userId,
-        }
-      )()
+      const { conProfile } = await fetcher<
+        LoadMyProfileQuery,
+        LoadMyProfileQueryVariables
+      >(LoadMyProfileDocument, {
+        loopbackUserId: getAccessTokenFromLocalStorage().userId,
+      })()
 
+      // Redirects mentee/mentor with status rejected/deactivated to /front/login-result
+      if (conProfile?.profileStatus === 'REJECTED' || `DEACTIVATED`) {
+        return history.push('/front/login-result')
+      }
       // TODO: insert proper error handling here and elsewhere. We should cover cases where we
       // get values usch as myProfileResult.isError. Perhaps we-ure the error boundary logic
       // that Eric has been looking into.

--- a/apps/redi-connect/src/pages/front/login/LoginError.tsx
+++ b/apps/redi-connect/src/pages/front/login/LoginError.tsx
@@ -1,0 +1,42 @@
+import {
+  Button,
+  Heading,
+} from '@talent-connect/shared-atomic-design-components'
+import { Columns, Content, Form } from 'react-bulma-components'
+import { useHistory } from 'react-router-dom'
+import { Teaser } from '../../../../../redi-connect/src/components/molecules'
+import AccountOperation from '../../../../../redi-connect/src/components/templates/AccountOperation'
+
+export default function LoginError() {
+  const history = useHistory()
+
+  return (
+    <AccountOperation>
+      <Columns vCentered>
+        <Columns.Column
+          size={6}
+          responsive={{ mobile: { hide: { value: true } } }}
+        >
+          <Teaser.IllustrationOnly />
+        </Columns.Column>
+        <Columns.Column size={5} offset={1}>
+          <Heading border="bottomLeft">Changes to Your Platform Access</Heading>
+          <Content size="large" renderAs="div">
+            <p>
+              Ooops! It seems like your access to the platform has changed, If
+              you believe this is a mistake or have any questions, please reach
+              out to us at{' '}
+              <a href="mailto:career@redi-school.org">career@redi-school.org</a>
+              . We're here to help!
+            </p>
+          </Content>
+          <Form.Field className="submit-spacer">
+            <Form.Control>
+              <Button onClick={() => history.push('/')}>Go Back</Button>
+            </Form.Control>
+          </Form.Field>
+        </Columns.Column>
+      </Columns>
+    </AccountOperation>
+  )
+}

--- a/apps/redi-connect/src/routes/routes__logged-out.tsx
+++ b/apps/redi-connect/src/routes/routes__logged-out.tsx
@@ -12,6 +12,12 @@ const Login = lazy(
       /* webpackChunkName: "Login", webpackPreload: true */ '../pages/front/login/Login'
     )
 )
+const LoginError = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "LoginError", webpackPreload: true */ '../pages/front/login/LoginError'
+    )
+)
 const SignUpLanding = lazy(
   () =>
     import(
@@ -67,6 +73,11 @@ export const routes__loggedOut: RouteDefinition[] = [
   {
     path: '/front/login',
     component: Login,
+    exact: true,
+  },
+  {
+    path: '/front/login-result',
+    component: LoginError,
     exact: true,
   },
   {

--- a/apps/redi-connect/src/services/api/api.tsx
+++ b/apps/redi-connect/src/services/api/api.tsx
@@ -40,7 +40,7 @@ export const login = async (
       RedProduct: 'CON',
     },
   })
-  const accessToken = loginResp.data as AccessToken
+  const accessToken = loginResp?.data as AccessToken
   saveAccessTokenToLocalStorage(accessToken)
   setGraphQlClientAuthHeader(accessToken)
   return accessToken


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
Ticket [#889](https://github.com/talent-connect/connect/issues/889)

## What should the reviewer know?
- adds notifications to both mentees and mentors with deactivated/rejected status
- adds /front/login-result route
- When con users with statuses deactivated/rejected login will get redirected to
/front/login-result without getting logged in.

Mentee status notification :

![Rejected mentee](https://github.com/talent-connect/connect/assets/17381734/8a2a9efc-8873-4fa9-b650-156ce3a8b13e)

Mentor status notification :

![Rejected mentor](https://github.com/talent-connect/connect/assets/17381734/7aceb788-f62b-4114-8bda-15aa64b2d6d7)

Mentee/Mentor login deactivated/rejected status:

![redirect](https://github.com/talent-connect/connect/assets/17381734/ed107310-c1fa-458d-9e4e-c146ec695daa)







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new notifications for rejected mentees and mentors.
  - Added a new `LoginError` component to inform users about changes to platform access.
  - Added a new route for the `LoginError` page.

- **Enhancements**
  - Improved login flow with conditional redirection based on profile status.
  - Updated API logic to handle potential null values more gracefully.

- **Bug Fixes**
  - Fixed issue where imports were not consistently organized on save in the editor settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->