### PR TITLE
Con Reminder Emails (Continued)

### DIFF
--- a/apps/nestjs-api/src/con-mentorship-matches/con-mentorship-matches.service.ts
+++ b/apps/nestjs-api/src/con-mentorship-matches/con-mentorship-matches.service.ts
@@ -105,12 +105,12 @@ export class ConMentorshipMatchesService {
       rediLocation: menteeProfile.props.rediLocation,
     })
 
-    const menteependingMenteeApplications = await this.findAll({
+    const menteePendingMenteeApplications = await this.findAll({
       Mentee__c: menteeProfile.props.userId,
       Status__c: MentorshipMatchStatus.APPLIED,
     })
 
-    menteependingMenteeApplications.forEach(async (match) => {
+    menteePendingMenteeApplications.forEach(async (match) => {
       match.props.status =
         MentorshipMatchStatus.INVALIDATED_AS_OTHER_MENTOR_ACCEPTED
       this.api.update(this.mapper.toPersistence(match))

--- a/apps/nestjs-api/src/con-mentorship-matches/con-mentorship-matches.service.ts
+++ b/apps/nestjs-api/src/con-mentorship-matches/con-mentorship-matches.service.ts
@@ -105,12 +105,12 @@ export class ConMentorshipMatchesService {
       rediLocation: menteeProfile.props.rediLocation,
     })
 
-    const menteePendingMentorshipMatches = await this.findAll({
+    const menteependingMenteeApplications = await this.findAll({
       Mentee__c: menteeProfile.props.userId,
       Status__c: MentorshipMatchStatus.APPLIED,
     })
 
-    menteePendingMentorshipMatches.forEach(async (match) => {
+    menteependingMenteeApplications.forEach(async (match) => {
       match.props.status =
         MentorshipMatchStatus.INVALIDATED_AS_OTHER_MENTOR_ACCEPTED
       this.api.update(this.mapper.toPersistence(match))

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
@@ -155,22 +155,22 @@ export class ReminderEmailsController {
   }
 
   @Get('/s3cr3t-3ndp01nt-t0-tr1gg3r-r3m1nd3r5/pending-mentorships')
-  async sendPendingMentorshipsReminder() {
-    const pendingMentorshipMatches =
-      await this.reminderEmailsService.getPendingMentorshipMatches()
+  async sendPendingMenteeApplicationReminder() {
+    const pendingMenteeApplications =
+      await this.reminderEmailsService.getpendingMenteeApplications()
 
-    if (Object.keys(pendingMentorshipMatches).length > 0) {
-      Object.keys(pendingMentorshipMatches).forEach(async (match) => {
+    if (Object.keys(pendingMenteeApplications).length > 0) {
+      Object.keys(pendingMenteeApplications).forEach(async (match) => {
         // Send reminder email to mentee
         await this.reminderEmailsService.sendMentorPendingApplicationReminder({
-          match: pendingMentorshipMatches[match],
+          match: pendingMenteeApplications[match],
         })
       })
     }
 
     return {
-      message: `Pending Mentorship Reminder emails sent to Mentors: ${
-        Object.keys(pendingMentorshipMatches).length
+      message: `Pending Mentee Applications Reminder emails sent to Mentors: ${
+        Object.keys(pendingMenteeApplications).length
       }`,
     }
   }

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
@@ -161,7 +161,7 @@ export class ReminderEmailsController {
 
     if (Object.keys(pendingMenteeApplications).length > 0) {
       Object.keys(pendingMenteeApplications).forEach(async (match) => {
-        // Send reminder email to mentee
+        // Send reminder email to mentor
         await this.reminderEmailsService.sendMentorPendingApplicationReminder({
           match: pendingMenteeApplications[match],
         })

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
@@ -27,7 +27,7 @@ export class ReminderEmailsController {
     }
 
     return {
-      message: `Complete Profile reminder emails sent to ${mentorsWithDraftingProfile.length} mentors`,
+      message: `Complete Profile Reminder Emails sent to Mentors: ${mentorsWithDraftingProfile.length}`,
     }
   }
 
@@ -50,7 +50,7 @@ export class ReminderEmailsController {
     }
 
     return {
-      message: `Complete Profile reminder emails sent to ${menteesWithDrafingProfile.length} mentees`,
+      message: `Complete Profile Reminder Emails Sent to Mentees: ${menteesWithDrafingProfile.length}`,
     }
   }
 
@@ -94,7 +94,7 @@ export class ReminderEmailsController {
     }
 
     return {
-      message: `First reminder emails to apply to a mentor sent to ${firstReminderMentees.length} mentees. Second reminder emails to apply to a mentor sent to ${secondReminderMentees.length} mentees`,
+      message: `Apply To a Mentor Reminder Emails sent: ${firstReminderMentees.length} first reminders, ${secondReminderMentees.length} second reminders`,
     }
   }
 
@@ -126,9 +126,9 @@ export class ReminderEmailsController {
     }
 
     return {
-      message: `Follow-up reminder emails sent to ${
+      message: `Mentorship Follow-up Reminder Emails Sent: ${
         Object.keys(threeMonthsOldMentorshipMatches).length
-      } mentorship matches`,
+      }`,
     }
   }
 
@@ -150,7 +150,7 @@ export class ReminderEmailsController {
     }
 
     return {
-      message: `Reminder emails sent to ${unmatchedMenteesFor45Days.length} unmatched mentees with approved profiles`,
+      message: `Platform Update Reminder Emails Sent to Mentees: ${unmatchedMenteesFor45Days.length}`,
     }
   }
 
@@ -169,9 +169,9 @@ export class ReminderEmailsController {
     }
 
     return {
-      message: `Pending Mentorship Reminder emails sent to ${
+      message: `Pending Mentorship Reminder emails sent to Mentors: ${
         Object.keys(pendingMentorshipMatches).length
-      } mentors`,
+      }`,
     }
   }
 

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
@@ -132,45 +132,45 @@ export class ReminderEmailsController {
     }
   }
 
-  // @Get('/s3cr3t-3ndp01nt-t0-tr1gg3r-r3m1nd3r5/mentees-platform-and-new-mentors')
-  // async sendUnmatchedMenteesReminder() {
-  //   const unmatchedMenteesWithApprovedProfiles =
-  //     await this.reminderEmailsService.getUnmatchedMenteesWithApprovedProfiles()
+  @Get('/s3cr3t-3ndp01nt-t0-tr1gg3r-r3m1nd3r5/mentees-platform-and-new-mentors')
+  async sendUnmatchedMenteesReminder() {
+    const unmatchedMenteesFor45Days =
+      await this.reminderEmailsService.getUnmatchedMenteesFor45Days()
 
-  //   if (unmatchedMenteesWithApprovedProfiles.length > 0) {
-  //     // send reminder emails
-  //     unmatchedMenteesWithApprovedProfiles.forEach(async (mentee) => {
-  //       await this.reminderEmailsService.sendMenteesPlatformAndNewMentorsReminder(
-  //         {
-  //           email: mentee.props.email,
-  //           firstName: mentee.props.firstName,
-  //         }
-  //       )
-  //     })
-  //   }
+    if (Object.keys(unmatchedMenteesFor45Days).length > 0) {
+      unmatchedMenteesFor45Days.forEach(async (mentee) => {
+        // Send reminder email to mentee
+        await this.reminderEmailsService.sendMenteesPlatformAndNewMentorsReminder(
+          {
+            email: mentee.props.email,
+            firstName: mentee.props.firstName,
+          }
+        )
+      })
+    }
 
-  //   return {
-  //     message: `Reminder emails sent to ${unmatchedMenteesWithApprovedProfiles.length} unmatched mentees with approved profiles`,
-  //   }
-  // }
-
-  // @Get('/s3cr3t-3ndp01nt-t0-tr1gg3r-r3m1nd3r5/mentoring-sessions-logging')
-  // async sendMentoringSessionsLoggingReminder() {
-  //   const conProfilesWithMentoringSessionsToLog =
-  //     await this.reminderEmailsService.getConProfilesWithMentorshipMatchesWithoutMentoringSessions(
-  //       { mentorshipMatchAgeInDays: 402 }
-  //     )
-
-  //   if (conProfilesWithMentoringSessionsToLog.length > 0) {
-  //     // send reminder emails
-  //     conProfilesWithMentoringSessionsToLog.forEach(async (profile) => {
-  //       await this.reminderEmailsService.sendLogMentoringSessionsReminder({
-  //         email: profile.props.email,
-  //         firstName: profile.props.firstName,
-  //         userType: profile.props.userType,
-  //         mentorshipMatchAgeInDays: 14,
-  //       })
-  //     })
-  //   }
-  // }
+    return {
+      message: `Reminder emails sent to ${unmatchedMenteesFor45Days.length} unmatched mentees with approved profiles`,
+    }
+  }
 }
+
+// @Get('/s3cr3t-3ndp01nt-t0-tr1gg3r-r3m1nd3r5/mentoring-sessions-logging')
+// async sendMentoringSessionsLoggingReminder() {
+//   const conProfilesWithMentoringSessionsToLog =
+//     await this.reminderEmailsService.getConProfilesWithMentorshipMatchesWithoutMentoringSessions(
+//       { mentorshipMatchAgeInDays: 402 }
+//     )
+
+//   if (conProfilesWithMentoringSessionsToLog.length > 0) {
+//     // send reminder emails
+//     conProfilesWithMentoringSessionsToLog.forEach(async (profile) => {
+//       await this.reminderEmailsService.sendLogMentoringSessionsReminder({
+//         email: profile.props.email,
+//         firstName: profile.props.firstName,
+//         userType: profile.props.userType,
+//         mentorshipMatchAgeInDays: 14,
+//       })
+//     })
+//   }
+// }

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
@@ -153,24 +153,45 @@ export class ReminderEmailsController {
       message: `Reminder emails sent to ${unmatchedMenteesFor45Days.length} unmatched mentees with approved profiles`,
     }
   }
+
+  @Get('/s3cr3t-3ndp01nt-t0-tr1gg3r-r3m1nd3r5/pending-mentorships')
+  async sendPendingMentorshipsReminder() {
+    const pendingMentorshipMatches =
+      await this.reminderEmailsService.getPendingMentorshipMatches()
+
+    if (Object.keys(pendingMentorshipMatches).length > 0) {
+      Object.keys(pendingMentorshipMatches).forEach(async (match) => {
+        // Send reminder email to mentee
+        await this.reminderEmailsService.sendMentorPendingApplicationReminder({
+          match: pendingMentorshipMatches[match],
+        })
+      })
+    }
+
+    return {
+      message: `Pending Mentorship Reminder emails sent to ${
+        Object.keys(pendingMentorshipMatches).length
+      } mentors`,
+    }
+  }
+
+  // @Get('/s3cr3t-3ndp01nt-t0-tr1gg3r-r3m1nd3r5/mentoring-sessions-logging')
+  // async sendMentoringSessionsLoggingReminder() {
+  //   const conProfilesWithMentoringSessionsToLog =
+  //     await this.reminderEmailsService.getConProfilesWithMentorshipMatchesWithoutMentoringSessions(
+  //       { mentorshipMatchAgeInDays: 402 }
+  //     )
+
+  //   if (conProfilesWithMentoringSessionsToLog.length > 0) {
+  //     // send reminder emails
+  //     conProfilesWithMentoringSessionsToLog.forEach(async (profile) => {
+  //       await this.reminderEmailsService.sendLogMentoringSessionsReminder({
+  //         email: profile.props.email,
+  //         firstName: profile.props.firstName,
+  //         userType: profile.props.userType,
+  //         mentorshipMatchAgeInDays: 14,
+  //       })
+  //     })
+  //   }
+  // }
 }
-
-// @Get('/s3cr3t-3ndp01nt-t0-tr1gg3r-r3m1nd3r5/mentoring-sessions-logging')
-// async sendMentoringSessionsLoggingReminder() {
-//   const conProfilesWithMentoringSessionsToLog =
-//     await this.reminderEmailsService.getConProfilesWithMentorshipMatchesWithoutMentoringSessions(
-//       { mentorshipMatchAgeInDays: 402 }
-//     )
-
-//   if (conProfilesWithMentoringSessionsToLog.length > 0) {
-//     // send reminder emails
-//     conProfilesWithMentoringSessionsToLog.forEach(async (profile) => {
-//       await this.reminderEmailsService.sendLogMentoringSessionsReminder({
-//         email: profile.props.email,
-//         firstName: profile.props.firstName,
-//         userType: profile.props.userType,
-//         mentorshipMatchAgeInDays: 14,
-//       })
-//     })
-//   }
-// }

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.controller.ts
@@ -157,7 +157,7 @@ export class ReminderEmailsController {
   @Get('/s3cr3t-3ndp01nt-t0-tr1gg3r-r3m1nd3r5/pending-mentorships')
   async sendPendingMenteeApplicationReminder() {
     const pendingMenteeApplications =
-      await this.reminderEmailsService.getpendingMenteeApplications()
+      await this.reminderEmailsService.getPendingMenteeApplications()
 
     if (Object.keys(pendingMenteeApplications).length > 0) {
       Object.keys(pendingMenteeApplications).forEach(async (match) => {

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
@@ -270,7 +270,7 @@ export class ReminderEmailsService {
   async getpendingMenteeApplications() {
     const threeMonthsOldMentorshipMatches =
       await this.conMentorshipMatchesService.findAll({
-        Mentorship_Match_Age_In_Days__c: 13,
+        Mentorship_Match_Age_In_Days__c: 90,
         Status__c: MentorshipMatchStatus.APPLIED,
       })
 
@@ -550,11 +550,11 @@ export class ReminderEmailsService {
   }) {
     const sfEmailTemplateDeveloperName =
       userType === UserType.MENTOR
-        ? // Mentor Emails for 2 and 4 weeks
+        ? // Mentor Emails for 2 weeks (14 days) and 4 weeks (28 days)
           mentorshipMatchAgeInDays === 14
           ? 'Mentor_Log_Mentoring_Sessions_Reminder_1_1711110740940'
           : 'Mentor_Log_Mentoring_Sessions_Reminder_2_1711112496532'
-        : // Mentee Emails for 2 and 4 weeks
+        : // Mentee Emails for 2 weeks (14 days) and 4 weeks (28 days)
         mentorshipMatchAgeInDays === 14
         ? 'Mentee_Log_Mentoring_Sessions_Reminder_1_1711114670729'
         : 'Mentee_Log_Mentoring_Sessions_Reminder_2_1711115347143'
@@ -577,8 +577,9 @@ export class ReminderEmailsService {
     const params = {
       Destination: {
         ToAddresses: isProductionOrDemonstration()
-          ? ['anilakarsu93@gmail.com']
+          ? [email]
           : [this.config.get('NX_DEV_MODE_EMAIL_RECIPIENT')],
+        BccAddresses: [SENDER_EMAIL],
       },
       Message: {
         Body: {
@@ -586,7 +587,7 @@ export class ReminderEmailsService {
         },
         Subject: { Data: template.Subject },
       },
-      Source: 'career@redi-school.org',
+      Source: `${SENDER_NAME} <${SENDER_EMAIL}>`,
     }
 
     this.ses.sendEmail(params, (err, data) => {

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
@@ -267,7 +267,7 @@ export class ReminderEmailsService {
   //   return []
   // }
 
-  async getPendingMentorshipMatches() {
+  async getpendingMenteeApplications() {
     const threeMonthsOldMentorshipMatches =
       await this.conMentorshipMatchesService.findAll({
         Mentorship_Match_Age_In_Days__c: 13,

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
@@ -105,7 +105,7 @@ export class ReminderEmailsService {
 
   async getUnmatchedMenteesFor45Days() {
     const approvedDate = new Date()
-    approvedDate.setDate(approvedDate.getDate() - 9)
+    approvedDate.setDate(approvedDate.getDate() - 45)
 
     // 1st Step: Get all approved mentees from the last 7 or 14 days
     const approvedMentees = await this.conProfilesService.findAll({

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
@@ -217,45 +217,6 @@ export class ReminderEmailsService {
     return transformedReducedMatches
   }
 
-  // async getUnmatchedMenteesWithApprovedProfiles() {
-  //   const approvedDate = new Date()
-  //   approvedDate.setDate(approvedDate.getDate() - 45) // Interestingly, parseInt is able to parse 7d and 14d to 7 and 14 respectively
-
-  //   return await this.conProfilesService.findAll({
-  //     'RecordType.DeveloperName': UserType.MENTEE,
-  //     Profile_Status__c: ConnectProfileStatus.APPROVED,
-  //     Profile_First_Approved_At__c: {
-  //       $eq: jsforce.SfDate.toDateLiteral(approvedDate),
-  //     },
-  //     'Contact__r.ReDI_Active_Mentorship_Matches_Mentee__c': null,
-  //   })
-  // }
-
-  // async getConProfilesWithMentorshipMatchesWithoutMentoringSessions({
-  //   mentorshipMatchAgeInDays,
-  // }: {
-  //   mentorshipMatchAgeInDays: number
-  // }) {
-  //   const matches = await this.conMentorshipMatchesService.findAll({
-  //     Status__c: MentorshipMatchStatus.ACCEPTED,
-  //     Mentorship_Match_Age_In_Days__c: mentorshipMatchAgeInDays,
-  //     of_Sessions__c: 0,
-  //   })
-
-  //   const menteeIds = matches.map((match) => match.props.menteeId)
-  //   const mentorIds = matches.map((match) => match.props.mentorId)
-
-  //   if ([...menteeIds, ...mentorIds].length > 0) {
-  //     return await this.conProfilesService.findAll({
-  //       'Contact__r.Id': {
-  //         $in: [...menteeIds, ...mentorIds],
-  //       },
-  //     })
-  //   }
-
-  //   return []
-  // }
-
   async getPendingMenteeApplications() {
     const pendingMentorshipApplications =
       await this.conMentorshipMatchesService.findAll({

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
@@ -135,13 +135,13 @@ export class ReminderEmailsService {
       (match) => match.props.menteeId
     )
 
-    // 4th Step: Find approved mentees that do not have a mentorship match or waiting applied
+    // 3rd Step: Find approved mentees that do not have a mentorship match or waiting applied
     const menteeIdsWithoutMentorshipMatch = difference(
       approvedMenteeIds,
       mentorshipMatchMenteeIds
     )
 
-    // 5th Step: Return approved mentees that do not have a mentorship match or waiting applied
+    // 4th Step: Return approved mentees that do not have a mentorship match or waiting applied
     if (menteeIdsWithoutMentorshipMatch.length > 0) {
       return approvedMenteesFrom45DaysAgo.filter((mentee) =>
         menteeIdsWithoutMentorshipMatch.includes(mentee.props.userId)

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
@@ -104,7 +104,7 @@ export class ReminderEmailsService {
 
   async getUnmatchedMenteesFor45Days() {
     const approvedDate = new Date()
-    approvedDate.setDate(approvedDate.getDate() - 44)
+    approvedDate.setDate(approvedDate.getDate() - 45)
 
     // 1st Step: Get all mentees that have been approved 45 days ago
     const approvedMenteesFrom45DaysAgo = await this.conProfilesService.findAll({

--- a/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
+++ b/apps/nestjs-api/src/reminder-emails/reminder-emails.service.ts
@@ -256,13 +256,13 @@ export class ReminderEmailsService {
   // }
 
   async getPendingMenteeApplications() {
-    const threeMonthsOldMentorshipMatches =
+    const pendingMentorshipApplications =
       await this.conMentorshipMatchesService.findAll({
-        Mentorship_Match_Age_In_Days__c: 90,
+        Mentorship_Match_Age_In_Days__c: 14,
         Status__c: MentorshipMatchStatus.APPLIED,
       })
 
-    const reducedMatches = threeMonthsOldMentorshipMatches.reduce(
+    const reducedMatches = pendingMentorshipApplications.reduce(
       (acc, match) => {
         acc[match.props.id] = {
           matchDate: match.props.createdAt,
@@ -275,10 +275,10 @@ export class ReminderEmailsService {
       {}
     )
 
-    const menteeIds = threeMonthsOldMentorshipMatches.map(
+    const menteeIds = pendingMentorshipApplications.map(
       (match) => match.props.menteeId
     )
-    const mentorIds = threeMonthsOldMentorshipMatches.map(
+    const mentorIds = pendingMentorshipApplications.map(
       (match) => match.props.mentorId
     )
 


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#712 

## What should the reviewer know?

Adding a new endpoint `sendUnmatchedMenteesReminder` to the `ReminderEmailsController` in `reminder-emails.controller.ts`. It retrieves a list of unmatched mentees for 45 days and sends reminder emails to each mentee. The email includes the mentee's email and first name.

Also includeing a return message indicating the number of reminder emails sent.

And adding a new endpoint in the `ReminderEmailsController` to send reminder emails to mentors with pending mentorship applications. The `sendPendingMentorshipsReminder` function retrieves the pending mentorship matches and sends reminder emails to the corresponding mentors. The number of reminder emails sent is included in the response message.

## Screenshots
![CleanShot 2024-06-27 at 22 25 02](https://github.com/talent-connect/connect/assets/6314657/19cffc24-6ca4-4582-bd73-7d314e4ee4af)

![CleanShot 2024-06-27 at 22 23 07](https://github.com/talent-connect/connect/assets/6314657/e02ad545-9d34-4660-b131-c50474e57026)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced reminders for pending mentorship matches.
  - Added functionality to handle unmatched mentees for 45 days.

- **Updates**
  - Enhanced clarity and consistency of reminder messages throughout the application.
  - Standardized sender information for email notifications.
  - Improved error handling in email-related processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->