### PR TITLE
feat: add login error page for redi-connect

### DIFF
--- a/apps/redi-connect/src/pages/app/me/Me.tsx
+++ b/apps/redi-connect/src/pages/app/me/Me.tsx
@@ -50,8 +50,6 @@ function Me() {
     },
     {
       onSuccess: (profile) => {
-        console.log('Me loaded it')
-
         if (
           profile?.conProfile?.profileStatus ===
             ConnectProfileStatus.Rejected ||

--- a/apps/redi-connect/src/pages/app/me/Me.tsx
+++ b/apps/redi-connect/src/pages/app/me/Me.tsx
@@ -20,7 +20,10 @@ import {
 } from '../../../components/organisms'
 
 import { LoggedIn } from '../../../components/templates'
-import { getAccessTokenFromLocalStorage } from '../../../services/auth/auth'
+import {
+  getAccessTokenFromLocalStorage,
+  purgeAllSessionData,
+} from '../../../services/auth/auth'
 
 import {
   ConnectProfileStatus,
@@ -31,6 +34,7 @@ import {
 import { REDI_LOCATION_NAMES } from '@talent-connect/shared-config'
 import { useLoading } from '../../../hooks/WithLoading'
 // CHECK OUT THE LOADER
+import { useHistory } from 'react-router-dom'
 import './Me.scss'
 import OnboardingSteps from './OnboardingSteps'
 
@@ -38,11 +42,27 @@ function Me() {
   const queryClient = useQueryClient()
   const submitProfileForReviewMutation = useConProfileSubmitForReviewMutation()
   const { Loading, isLoading } = useLoading()
+  const history = useHistory()
+
   const myProfileResult = useLoadMyProfileQuery(
     {
       loopbackUserId: getAccessTokenFromLocalStorage().userId,
     },
-    { onSuccess: () => console.log('Me loaded it') }
+    {
+      onSuccess: (profile) => {
+        console.log('Me loaded it')
+
+        if (
+          profile?.conProfile?.profileStatus ===
+            ConnectProfileStatus.Rejected ||
+          profile?.conProfile?.profileStatus ===
+            ConnectProfileStatus.Deactivated
+        ) {
+          purgeAllSessionData()
+          history.push('/front/login-result')
+        }
+      },
+    }
   )
 
   // TODO: insert proper error handling here and elsewhere. We should cover cases where we

--- a/apps/redi-connect/src/pages/front/login/LoginError.tsx
+++ b/apps/redi-connect/src/pages/front/login/LoginError.tsx
@@ -24,10 +24,10 @@ export default function LoginError() {
           <Content size="large" renderAs="div">
             <p>
               Oops! It seems like your access to the platform has changed. If
-              you believe this is a mistake or have any questions, please reach
-              out to Janis at{' '}
+              you believe this is a mistake or have any questions, please get in
+              touch with us at{' '}
               <a href="mailto:partner@redi-school.org">
-                partner@redi-school.org
+                career@redi-school.org
               </a>
               . We're here to help!
             </p>

--- a/apps/redi-connect/src/pages/front/login/LoginError.tsx
+++ b/apps/redi-connect/src/pages/front/login/LoginError.tsx
@@ -1,0 +1,44 @@
+import {
+  Button,
+  Heading,
+} from '@talent-connect/shared-atomic-design-components'
+import { Columns, Content, Form } from 'react-bulma-components'
+import { useHistory } from 'react-router-dom'
+import { Teaser } from '../../../../../redi-connect/src/components/molecules'
+import AccountOperation from '../../../../../redi-connect/src/components/templates/AccountOperation'
+
+export default function LoginError() {
+  const history = useHistory()
+
+  return (
+    <AccountOperation>
+      <Columns vCentered>
+        <Columns.Column
+          size={6}
+          responsive={{ mobile: { hide: { value: true } } }}
+        >
+          <Teaser.IllustrationOnly />
+        </Columns.Column>
+        <Columns.Column size={5} offset={1}>
+          <Heading border="bottomLeft">Changes to Your Platform Access</Heading>
+          <Content size="large" renderAs="div">
+            <p>
+              Oops! It seems like your access to the platform has changed. If
+              you believe this is a mistake or have any questions, please reach
+              out to Janis at{' '}
+              <a href="mailto:partner@redi-school.org">
+                partner@redi-school.org
+              </a>
+              . We're here to help!
+            </p>
+          </Content>
+          <Form.Field className="submit-spacer">
+            <Form.Control>
+              <Button onClick={() => history.push('/')}>Go Back</Button>
+            </Form.Control>
+          </Form.Field>
+        </Columns.Column>
+      </Columns>
+    </AccountOperation>
+  )
+}

--- a/apps/redi-connect/src/routes/routes__logged-out.tsx
+++ b/apps/redi-connect/src/routes/routes__logged-out.tsx
@@ -12,6 +12,12 @@ const Login = lazy(
       /* webpackChunkName: "Login", webpackPreload: true */ '../pages/front/login/Login'
     )
 )
+const LoginError = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "LoginError", webpackPreload: true */ '../pages/front/login/LoginError'
+    )
+)
 const SignUpLanding = lazy(
   () =>
     import(
@@ -67,6 +73,11 @@ export const routes__loggedOut: RouteDefinition[] = [
   {
     path: '/front/login',
     component: Login,
+    exact: true,
+  },
+  {
+    path: '/front/login-result',
+    component: LoginError,
     exact: true,
   },
   {

--- a/apps/redi-talent-pool/src/pages/app/me/Me.tsx
+++ b/apps/redi-talent-pool/src/pages/app/me/Me.tsx
@@ -1,5 +1,6 @@
 import { useMyTpDataQuery } from '@talent-connect/data-access'
 import { Loader } from '@talent-connect/shared-atomic-design-components'
+import { purgeAllSessionData } from 'apps/redi-connect/src/services/auth/auth'
 import { Redirect, useHistory } from 'react-router-dom'
 import { MeCompany } from './MeCompany'
 
@@ -28,6 +29,7 @@ function Me() {
       break
     case 'REJECTED':
     case 'DEACTIVATED':
+      purgeAllSessionData()
       history.push('/front/login-result')
       break
     case 'APPROVED':


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.
#889 

## What should the reviewer know?
This PR is doing the same as #918 but in a different way, so we don't have the issue with Connect sign-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new `LoginError` component to inform users about platform access changes and provide navigation back to the home page.
  - Enhanced profile management: Users whose profiles are rejected or deactivated will now have their session data purged and will be redirected to the login results page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->