### PR TITLE
feat(con): add Cybersecurity to the mentoring topics list

### DIFF
--- a/libs/common-types/src/lib/con-profile/enums/mentoring-topic.enum.ts
+++ b/libs/common-types/src/lib/con-profile/enums/mentoring-topic.enum.ts
@@ -16,6 +16,7 @@ export enum MentoringTopic {
   'iot' = 'iot',
   'computerNetworking' = 'computerNetworking',
   'blockchain' = 'blockchain',
+  'cybersecurity' = 'cybersecurity',
   'productManagement' = 'productManagement',
   'projectManagement' = 'projectManagement',
   'digitalMarketing' = 'digitalMarketing',

--- a/libs/data-access/src/lib/types/types.ts
+++ b/libs/data-access/src/lib/types/types.ts
@@ -486,6 +486,7 @@ export enum MentoringTopic {
   CareerOrientationAndPlanning = 'careerOrientationAndPlanning',
   CodingChallengePreparation = 'codingChallengePreparation',
   ComputerNetworking = 'computerNetworking',
+  Cybersecurity = 'cybersecurity',
   DataAnalytics = 'dataAnalytics',
   DevOpsCloud = 'devOpsCloud',
   DigitalMarketing = 'digitalMarketing',

--- a/libs/shared-config/src/lib/config.ts
+++ b/libs/shared-config/src/lib/config.ts
@@ -60,6 +60,7 @@ export const CATEGORIES = [
     group: 'softwareEngineering',
   },
   { id: 'blockchain', label: 'Blockchain', group: 'softwareEngineering' },
+  { id: 'cybersecurity', label: 'Cybersecurity', group: 'softwareEngineering' },
   {
     id: 'productManagement',
     label: 'Product Management',

--- a/schema.graphql
+++ b/schema.graphql
@@ -464,6 +464,7 @@ enum MentoringTopic {
   careerOrientationAndPlanning
   codingChallengePreparation
   computerNetworking
+  cybersecurity
   dataAnalytics
   devOpsCloud
   digitalMarketing


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Closes #925 

## What should the reviewer know?

Salesforce changes:
- Added a new value **Cybersecurity** to the mentoring topics list on `partial`, `contp` & `production` Orgs

Codebase changes:
- Added a new value **Cybersecurity** to the mentoring topics list

## Screenshots
<img width="842" alt="image" src="https://github.com/talent-connect/connect/assets/51786805/834d67bf-9f33-4e9d-82db-7f6d76bc3b4c">

<img width="920" alt="image" src="https://github.com/talent-connect/connect/assets/51786805/d7ebe5eb-09ed-4455-b699-27455dde3c3c">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added 'Cybersecurity' as a new mentoring topic across various sections of the platform, including user profiles and search categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->