### PR TITLE
hotfix(tp): resolve Company Profile status reverting to previous value after set to "Profile Approved" by SF admin

### DIFF
--- a/apps/nestjs-api/src/tp-company-profiles/tp-company-profiles-salesforce-event-handler.service.ts
+++ b/apps/nestjs-api/src/tp-company-profiles/tp-company-profiles-salesforce-event-handler.service.ts
@@ -41,6 +41,14 @@ export class TpCompanyProfilesSalesforceEventHandlerService {
       const updatedCompanyProfileProps = Object.assign(
         {},
         companyProfile.props,
+        // Even though this function is run as a result of .status changing in Salesforce,
+        // we observed that when retrieving the companyProfile from Salesforce (a few lines
+        // above), companyProfile.props.status would contain the OLD value! So, when for
+        // example .status was changed from DRAFTING_PROFILE to PROFILE_APPROVED by a
+        // Salesforce admin, when this code ran, .status would contain DRAFTING_PROFILE.
+        // We therefore need to avoid setting .status _back to_ DRAFTING_PROFILE 🤦‍♀️...
+        // by setting it to the new value it's supposed to have.
+        { state: payload.newStatus },
         { isProfileVisibleToJobseekers: true }
       )
       const updatedCompanyProfile = TpCompanyProfileEntity.create(


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

## What should the reviewer know?

This PR fixes a bug where a Company Profile's status would "magically" jump back to its previous value after a Salesforce user set it to `Profile Approved`. For example, when switching status from `Drafting Profile` to `Profile Approved`, the status would **be set _back to_ "Drafting Profile"**.

See the detailed comment inside the changed code for what specifically caused the bug and how it's been solved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where the company profile status was incorrectly reverted to an old value upon Salesforce event triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->