### PR TITLE
Feature tp adding confirmation dialogue

### DIFF
--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableEducation.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableEducation.tsx
@@ -388,6 +388,7 @@ function JobseekerFormSectionEducation({
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                     >
+                      {console.log(formik?.values)}
                       <FormDraggableAccordion
                         title={
                           item.title ? item.title : 'Click me to add details'
@@ -396,6 +397,7 @@ function JobseekerFormSectionEducation({
                         closeAccordionSignalSubject={
                           closeAllAccordionsSignalSubject.current
                         }
+                        entryCategory="education"
                       >
                         <FormInput
                           name={`education[${index}].title`}

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableEducation.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableEducation.tsx
@@ -14,6 +14,7 @@ import {
   FormSelect,
   FormTextArea,
   Icon,
+  LightModal,
 } from '@talent-connect/shared-atomic-design-components'
 import {
   certificationTypes,
@@ -160,6 +161,10 @@ function JobseekerFormSectionEducation({
   setIsEditing,
   setIsFormDirty,
 }: JobseekerFormSectionEducationProps) {
+  const [educationIdToRemove, setEducationIdToRemove] = useState<
+    string | undefined
+  >()
+
   const queryClient = useQueryClient()
   const myData = useMyTpDataQuery()
   const patchMutation = useTpJobseekerProfileEducationRecordPatchMutation()
@@ -362,6 +367,7 @@ function JobseekerFormSectionEducation({
         'education',
         formik.values?.education?.filter((item) => item.id !== id)
       )
+      setEducationIdToRemove(undefined)
     },
     [formik]
   )
@@ -392,11 +398,10 @@ function JobseekerFormSectionEducation({
                         title={
                           item.title ? item.title : 'Click me to add details'
                         }
-                        onRemove={() => onRemove(item.id)}
+                        onRemove={() => setEducationIdToRemove(item.id)}
                         closeAccordionSignalSubject={
                           closeAllAccordionsSignalSubject.current
                         }
-                        entryCategory="education"
                       >
                         <FormInput
                           name={`education[${index}].title`}
@@ -490,6 +495,15 @@ function JobseekerFormSectionEducation({
             </div>
           )}
         </Droppable>
+        <LightModal
+          isOpen={Boolean(educationIdToRemove)}
+          handleClose={() => setEducationIdToRemove(undefined)}
+          headline="Delete education entry?"
+          message="You will lose all the information entered for this education entry."
+          ctaLabel="Delete"
+          ctaOnClick={() => onRemove(educationIdToRemove)}
+          cancelLabel="Keep it"
+        />
       </DragDropContext>
 
       <div style={{ height: '30px' }} />

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableEducation.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableEducation.tsx
@@ -388,7 +388,6 @@ function JobseekerFormSectionEducation({
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                     >
-                      {console.log(formik?.values)}
                       <FormDraggableAccordion
                         title={
                           item.title ? item.title : 'Click me to add details'

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableProfessionalExperience.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableProfessionalExperience.tsx
@@ -386,6 +386,7 @@ export function JobseekerFormSectionProfessionalExperience({
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                     >
+                      {console.log(formik?.values)}
                       <FormDraggableAccordion
                         title={
                           item.title ? item.title : 'Click me to add details'
@@ -394,6 +395,7 @@ export function JobseekerFormSectionProfessionalExperience({
                         closeAccordionSignalSubject={
                           closeAllAccordionsSignalSubject.current
                         }
+                        entryCategory="professional"
                       >
                         <FormInput
                           name={`experience[${index}].title`}

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableProfessionalExperience.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableProfessionalExperience.tsx
@@ -15,6 +15,7 @@ import {
   FormSelect,
   FormTextArea,
   Icon,
+  LightModal,
 } from '@talent-connect/shared-atomic-design-components'
 import { formMonthsOptions } from '@talent-connect/talent-pool/config'
 import { reorder } from '@talent-connect/typescript-utilities'
@@ -174,6 +175,10 @@ export function JobseekerFormSectionProfessionalExperience({
   const createMutation = useTpJobseekerProfileExperienceRecordCreateMutation()
   const removedRecords = useRef<Array<string>>([])
   const isBusy = useIsBusy()
+
+  const [experienceIdToRemove, setExperienceIdToRemove] = useState<
+    string | undefined
+  >()
 
   const closeAllAccordionsSignalSubject = useRef(new Subject<void>())
 
@@ -360,6 +365,7 @@ export function JobseekerFormSectionProfessionalExperience({
         'experience',
         formik.values?.experience?.filter((item) => item.id !== id)
       )
+      setExperienceIdToRemove(undefined)
     },
     [formik]
   )
@@ -390,7 +396,7 @@ export function JobseekerFormSectionProfessionalExperience({
                         title={
                           item.title ? item.title : 'Click me to add details'
                         }
-                        onRemove={() => onRemove(item.id)}
+                        onRemove={() => setExperienceIdToRemove(item.id)}
                         closeAccordionSignalSubject={
                           closeAllAccordionsSignalSubject.current
                         }
@@ -486,6 +492,15 @@ export function JobseekerFormSectionProfessionalExperience({
             </div>
           )}
         </Droppable>
+        <LightModal
+          isOpen={Boolean(experienceIdToRemove)}
+          handleClose={() => setExperienceIdToRemove(undefined)}
+          headline="Delete professional experience?"
+          message="You will lose all the information entered for this professional experience."
+          ctaLabel="Delete"
+          ctaOnClick={() => onRemove(experienceIdToRemove)}
+          cancelLabel="Keep it"
+        />
       </DragDropContext>
 
       <div style={{ height: '30px' }} />

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableProfessionalExperience.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableProfessionalExperience.tsx
@@ -386,7 +386,6 @@ export function JobseekerFormSectionProfessionalExperience({
                       {...provided.draggableProps}
                       {...provided.dragHandleProps}
                     >
-                      {console.log(formik?.values)}
                       <FormDraggableAccordion
                         title={
                           item.title ? item.title : 'Click me to add details'

--- a/libs/shared-atomic-design-components/src/lib/atoms/FormDraggableAccordion.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/FormDraggableAccordion.tsx
@@ -6,6 +6,7 @@ import { Icon } from '../atoms'
 import './FormDraggableAccordion.scss'
 
 import { ReactComponent as AccordionHandleIcon } from '../../assets/images/accordion-handle.svg'
+import { LightModal } from '../molecules'
 
 interface Props {
   title: string
@@ -13,6 +14,7 @@ interface Props {
   initialOpen?: boolean
   onRemove?: () => void
   closeAccordionSignalSubject?: Subject<void>
+  entryCategory?: string
 }
 
 function FormDraggableAccordion({
@@ -21,8 +23,16 @@ function FormDraggableAccordion({
   onRemove = null,
   initialOpen = false,
   closeAccordionSignalSubject = null,
+  entryCategory,
 }: Props) {
   const [showAnswer, setShowAnswer] = useState(initialOpen)
+  const [
+    deleteModalOpenForProExperience,
+    setDeleteModalOpenForJobProExperience,
+  ] = useState<boolean>(false)
+
+  const openDeleteModal = () => setDeleteModalOpenForJobProExperience(true)
+  const closeDeleteModal = () => setDeleteModalOpenForJobProExperience(false)
 
   useEffect(() => {
     const sub = closeAccordionSignalSubject?.subscribe(() =>
@@ -31,20 +41,26 @@ function FormDraggableAccordion({
 
     return () => sub?.unsubscribe()
   }, [closeAccordionSignalSubject])
+  console.log(children)
+
+  const modalHeadline =
+    entryCategory === 'education'
+      ? 'Delete education entry?'
+      : 'Delete professional experience?'
+  const modalMessage =
+    entryCategory === 'education'
+      ? 'You will lose all the information entered for this education entry.'
+      : 'You will lose all the information entered for this professional experience.'
 
   return (
     <div className="form-draggable-accordion">
-      <Columns
-        breakpoint="mobile"
-        className="form-draggable-accordion__title"
-        onClick={() => setShowAnswer(!showAnswer)}
-      >
-        <Columns.Column>
+      <Columns breakpoint="mobile" className="form-draggable-accordion__title">
+        <Columns.Column onClick={() => setShowAnswer(!showAnswer)}>
           <Element style={{ display: 'flex' }}>
             <AccordionHandleIcon style={{ marginRight: '.8rem' }} /> {title}
           </Element>
         </Columns.Column>
-        <Columns.Column narrow>
+        <Columns.Column onClick={() => setShowAnswer(!showAnswer)} narrow>
           <Icon
             icon="chevron"
             size="small"
@@ -53,8 +69,17 @@ function FormDraggableAccordion({
         </Columns.Column>
         <Columns.Column narrow>
           {onRemove ? (
-            <Icon icon="cancel" size="small" onClick={onRemove} />
+            <Icon icon="cancel" size="small" onClick={openDeleteModal} />
           ) : null}
+          <LightModal
+            isOpen={deleteModalOpenForProExperience}
+            handleClose={closeDeleteModal}
+            headline={modalHeadline}
+            message={modalMessage}
+            ctaLabel="Delete"
+            ctaOnClick={onRemove}
+            cancelLabel="Keep it"
+          />
         </Columns.Column>
       </Columns>
       <Element

--- a/libs/shared-atomic-design-components/src/lib/atoms/FormDraggableAccordion.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/FormDraggableAccordion.tsx
@@ -26,13 +26,10 @@ function FormDraggableAccordion({
   entryCategory,
 }: Props) {
   const [showAnswer, setShowAnswer] = useState(initialOpen)
-  const [
-    deleteModalOpenForProExperience,
-    setDeleteModalOpenForJobProExperience,
-  ] = useState<boolean>(false)
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false)
 
-  const openDeleteModal = () => setDeleteModalOpenForJobProExperience(true)
-  const closeDeleteModal = () => setDeleteModalOpenForJobProExperience(false)
+  const openDeleteModal = () => setIsDeleteModalOpen(true)
+  const closeDeleteModal = () => setIsDeleteModalOpen(false)
 
   useEffect(() => {
     const sub = closeAccordionSignalSubject?.subscribe(() =>
@@ -41,7 +38,6 @@ function FormDraggableAccordion({
 
     return () => sub?.unsubscribe()
   }, [closeAccordionSignalSubject])
-  console.log(children)
 
   const modalHeadline =
     entryCategory === 'education'
@@ -72,7 +68,7 @@ function FormDraggableAccordion({
             <Icon icon="cancel" size="small" onClick={openDeleteModal} />
           ) : null}
           <LightModal
-            isOpen={deleteModalOpenForProExperience}
+            isOpen={isDeleteModalOpen}
             handleClose={closeDeleteModal}
             headline={modalHeadline}
             message={modalMessage}

--- a/libs/shared-atomic-design-components/src/lib/atoms/FormDraggableAccordion.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/FormDraggableAccordion.tsx
@@ -6,7 +6,6 @@ import { Icon } from '../atoms'
 import './FormDraggableAccordion.scss'
 
 import { ReactComponent as AccordionHandleIcon } from '../../assets/images/accordion-handle.svg'
-import { LightModal } from '../molecules'
 
 interface Props {
   title: string
@@ -26,10 +25,6 @@ function FormDraggableAccordion({
   entryCategory,
 }: Props) {
   const [showAnswer, setShowAnswer] = useState(initialOpen)
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false)
-
-  const openDeleteModal = () => setIsDeleteModalOpen(true)
-  const closeDeleteModal = () => setIsDeleteModalOpen(false)
 
   useEffect(() => {
     const sub = closeAccordionSignalSubject?.subscribe(() =>
@@ -65,17 +60,8 @@ function FormDraggableAccordion({
         </Columns.Column>
         <Columns.Column narrow>
           {onRemove ? (
-            <Icon icon="cancel" size="small" onClick={openDeleteModal} />
+            <Icon icon="cancel" size="small" onClick={onRemove} />
           ) : null}
-          <LightModal
-            isOpen={isDeleteModalOpen}
-            handleClose={closeDeleteModal}
-            headline={modalHeadline}
-            message={modalMessage}
-            ctaLabel="Delete"
-            ctaOnClick={onRemove}
-            cancelLabel="Keep it"
-          />
         </Columns.Column>
       </Columns>
       <Element


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

[ticket 903](https://github.com/talent-connect/connect/issues/903)

## What should the reviewer know?
Overview:

This update enhances the FormDraggableAccordion component with improved modal functionality for deletion confirmation.

Details:

- Introduced an optional `entryCategory` prop to the `FormDraggableAccordion` component. This prop can be used to specify the type of entry (e.g., 'professional' or 'education').
- Updated the component to show a contextual modal when the remove icon is clicked. The modal's headline and message now vary based on the value of `entryCategory`.
- Added functions `openDeleteModal` and `closeDeleteModal` to manage the state of the modal.
- Included the `LightModal` component to confirm deletion, using the `entryCategory` to determine the appropriate text.
- Ensured backward compatibility with the existing props and logic by making `entryCategory` optional.

![screen-capture (3)](https://github.com/user-attachments/assets/de77da5b-8203-4f4b-a61c-9da375286212)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new props for categorizing form sections as "education" and "professional" in jobseeker profiles.
  - Added a confirmation modal for deletion actions in the FormDraggableAccordion component, enhancing user experience with clear prompts based on the entry category.

- **Bug Fixes**
  - Improved handling of modal visibility and functionality for deletion confirmation, preventing accidental data loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->