### PR TITLE
removing flex-wrap from tablet query to prevent overlaping issue in t…

### DIFF
--- a/apps/redi-talent-pool/src/pages/app/job-listing/JobListing.scss
+++ b/apps/redi-talent-pool/src/pages/app/job-listing/JobListing.scss
@@ -153,7 +153,6 @@
     align-items: center;
 
     @include tablet() {
-      flex-wrap: wrap;
       text-overflow: ellipsis;
       white-space: none;
     }
@@ -181,7 +180,6 @@
       line-height: 40px;
       overflow: hidden;
       display: -webkit-box;
-      -webkit-box-orient: vertical;
       -webkit-line-clamp: 2; /* Limits the text to 2 lines */
       text-overflow: ellipsis;
       max-height: 80px;


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

[933](https://github.com/talent-connect/connect/issues/933)

## What should the reviewer know?

This PR addresses the following issues related to the display of job listings with long position names:

Desktop: Fixed the overlapping issue where the general info (position name, company name, last updated date, location) was pushed down and overlapped with the "About the role" section by removing flex-wrap from the tablet media query.

Mobile: Resolved the issue where the position name was truncated and replaced with "..." by removing -webkit-box-orient: vertical, allowing the full job title to be visible.



https://github.com/user-attachments/assets/f8ba6c39-6992-4f72-b7a5-5dd8300852de

