### PR TITLE
bugfix(tp): fix pagination for filters on the 'Browse Jobseekers' page

### DIFF
--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -150,18 +150,20 @@ export function BrowseCompany() {
     )
   }
 
+  const resetPaginationPageNumber = () => setCurrentPageNumber(1)
+
   const toggleOnlyFavoritesFilter = () => {
     setQuery((latestQuery) => ({
       ...latestQuery,
       onlyFavorites: onlyFavorites ? undefined : true,
     }))
-    setCurrentPageNumber(1)
+    resetPaginationPageNumber()
   }
 
   const toggleFilters = (filtersArr, filterName, item) => {
     const newFilters = toggleValueInArray(filtersArr, item)
     setQuery((latestQuery) => ({ ...latestQuery, [filterName]: newFilters }))
-    setCurrentPageNumber(1)
+    resetPaginationPageNumber()
   }
 
   /**
@@ -175,12 +177,12 @@ export function BrowseCompany() {
   //     joinsMunich24SummerJobFair:
   //       joinsMunich24SummerJobFair === undefined ? true : undefined,
   //   }))
-  //   setCurrentPageNumber(1)
+  //   resetPaginationPageNumber()
   // }
 
   const setName = (value) => {
     setQuery((latestQuery) => ({ ...latestQuery, name: value || undefined }))
-    setCurrentPageNumber(1)
+    resetPaginationPageNumber()
   }
 
   const clearFilters = () => {
@@ -198,7 +200,7 @@ export function BrowseCompany() {
        */
       // joinsMunich24SummerJobFair: undefined,
     }))
-    setCurrentPageNumber(1)
+    resetPaginationPageNumber()
   }
 
   const shouldShowFilters =

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -155,11 +155,13 @@ export function BrowseCompany() {
       ...latestQuery,
       onlyFavorites: onlyFavorites ? undefined : true,
     }))
+    setCurrentPageNumber(1)
   }
 
   const toggleFilters = (filtersArr, filterName, item) => {
     const newFilters = toggleValueInArray(filtersArr, item)
     setQuery((latestQuery) => ({ ...latestQuery, [filterName]: newFilters }))
+    setCurrentPageNumber(1)
   }
 
   /**
@@ -167,15 +169,18 @@ export function BrowseCompany() {
    * Uncomment & Rename (joins{Location}{Year}{Season}JobFair) the next method when there's an upcoming Job Fair
    * Duplicate if there are multiple Job Fairs coming
    */
-  // const toggleMunich24SummerJobFairFilter = () =>
+  // const toggleMunich24SummerJobFairFilter = () => {
   //   setQuery((latestQuery) => ({
   //     ...latestQuery,
   //     joinsMunich24SummerJobFair:
   //       joinsMunich24SummerJobFair === undefined ? true : undefined,
   //   }))
+  //   setCurrentPageNumber(1)
+  // }
 
   const setName = (value) => {
     setQuery((latestQuery) => ({ ...latestQuery, name: value || undefined }))
+    setCurrentPageNumber(1)
   }
 
   const clearFilters = () => {
@@ -193,6 +198,7 @@ export function BrowseCompany() {
        */
       // joinsMunich24SummerJobFair: undefined,
     }))
+    setCurrentPageNumber(1)
   }
 
   const shouldShowFilters =


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

When the user applies filters on the 'Browse Jobseekers' page, we should set the current pagination page to 1 for each filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved pagination control: The current page resets to 1 when filters are toggled or the name is set, enhancing user experience by ensuring relevant results are displayed.

- **Bug Fixes**
	- Ensured consistency in displayed results with updated filter settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->