### PR TITLE
Adjusted CV BUILDER heading

### DIFF
--- a/apps/redi-connect/src/pages/front/signup/SignUpLanding.scss
+++ b/apps/redi-connect/src/pages/front/signup/SignUpLanding.scss
@@ -15,10 +15,12 @@
   &__type {
     padding: 1.125rem 0;
     width: 48%;
-    text-align: center;
     border: 2px solid transparent;
     box-shadow: $default-shadow;
     cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     @include mobile() {
       width: 100%;
@@ -35,9 +37,6 @@
   }
 }
 
-.signup__type svg {
-  display: inline;
-}
 .no-shadow {
   box-shadow: none;
 }

--- a/apps/redi-connect/src/pages/front/signup/SignUpLanding.scss
+++ b/apps/redi-connect/src/pages/front/signup/SignUpLanding.scss
@@ -35,6 +35,9 @@
   }
 }
 
+.signup__type svg {
+  display: inline;
+}
 .no-shadow {
   box-shadow: none;
 }

--- a/apps/redi-talent-pool/src/pages/app/cv-builder/cv-list/CvListPage.scss
+++ b/apps/redi-talent-pool/src/pages/app/cv-builder/cv-list/CvListPage.scss
@@ -1,3 +1,4 @@
 .heading {
   font-family: Avenir LT Std;
+  padding-top: 2rem;
 }

--- a/apps/redi-talent-pool/src/pages/app/cv-builder/cv-list/CvListPage.scss
+++ b/apps/redi-talent-pool/src/pages/app/cv-builder/cv-list/CvListPage.scss
@@ -1,4 +1,10 @@
 .heading {
   font-family: Avenir LT Std;
-  padding-top: 2rem;
+
+  &__main {
+    padding-top: 2rem;
+    padding-bottom: 0.5rem;
+  }
 }
+
+

--- a/apps/redi-talent-pool/src/pages/app/cv-builder/cv-list/CvListPage.scss
+++ b/apps/redi-talent-pool/src/pages/app/cv-builder/cv-list/CvListPage.scss
@@ -1,10 +1,3 @@
-.heading {
-  font-family: Avenir LT Std;
-
-  &__main {
-    padding-top: 2rem;
-    padding-bottom: 0.5rem;
-  }
+.heading-section {
+  margin: 2rem 0 0 0;
 }
-
-

--- a/apps/redi-talent-pool/src/pages/app/cv-builder/cv-list/CvListPage.tsx
+++ b/apps/redi-talent-pool/src/pages/app/cv-builder/cv-list/CvListPage.tsx
@@ -70,7 +70,7 @@ function CvListPage() {
       <Columns>
         <Columns.Column size={12} paddingless>
           <Columns.Column size={4} paddingless>
-            <Heading size="smaller" className="heading">
+            <Heading size="smaller" className="heading heading__main">
               CV BUILDER
             </Heading>
             <Heading size="medium" border="bottomLeft" className="heading">

--- a/apps/redi-talent-pool/src/pages/app/cv-builder/cv-list/CvListPage.tsx
+++ b/apps/redi-talent-pool/src/pages/app/cv-builder/cv-list/CvListPage.tsx
@@ -3,12 +3,13 @@ import { useHistory } from 'react-router-dom'
 
 import {
   Button,
+  Caption,
   FormInput,
   Heading,
   Icon,
   Modal,
 } from '@talent-connect/shared-atomic-design-components'
-import { Box, Columns, Content, Section } from 'react-bulma-components'
+import { Box, Columns, Content, Element, Section } from 'react-bulma-components'
 
 import { EmptySectionPlaceholder } from '../../../../components/molecules/EmptySectionPlaceholder'
 import { LoggedIn } from '../../../../components/templates'
@@ -67,19 +68,22 @@ function CvListPage() {
    */
   return (
     <LoggedIn>
-      <Columns>
+      <Columns className="heading-section">
         <Columns.Column size={12} paddingless>
           <Columns.Column size={4} paddingless>
-            <Heading size="smaller" className="heading heading__main">
-              CV BUILDER
-            </Heading>
-            <Heading size="medium" border="bottomLeft" className="heading">
+            <Caption>CV Builder</Caption>
+            <Heading subtitle size="small" border="bottomLeft">
               Welcome to the CV Builder tool!
             </Heading>
           </Columns.Column>
         </Columns.Column>
-        <Columns.Column desktop={{ size: 12 }} mobile={{ size: 6 }} paddingless>
-          <Columns.Column size={6} paddingless style={{ marginBottom: 60 }}>
+        <Columns.Column desktop={{ size: 12 }} paddingless>
+          <Columns.Column
+            desktop={{ size: 6 }}
+            mobile={{ size: 12 }}
+            paddingless
+            style={{ marginBottom: 60 }}
+          >
             <Content>
               We build that tool to help you create, fast and easy, a perfect CV
               to download and apply for your desired position.
@@ -88,9 +92,9 @@ function CvListPage() {
         </Columns.Column>
         <Columns.Column
           desktop={{ size: 3 }}
-          mobile={{ size: 6 }}
+          mobile={{ size: 7 }}
           paddingless
-          style={{ marginBottom: 100 }}
+          style={{ marginBottom: 60 }}
         >
           <Button fullWidth onClick={() => toggleCvNameModal(true)}>
             Create a CV
@@ -104,7 +108,9 @@ function CvListPage() {
           marginBottom: 32,
         }}
       >
-        <Heading size="small">Your CVs</Heading>
+        <Element renderAs="h4" textSize={4}>
+          Your CVs
+        </Element>
       </Section>
       <Section paddingless>
         {cvList?.length > 0 ? (

--- a/apps/redi-talent-pool/src/pages/front/signup/SignUpLanding.scss
+++ b/apps/redi-talent-pool/src/pages/front/signup/SignUpLanding.scss
@@ -15,10 +15,12 @@
   &__type {
     padding: 1.125rem 0;
     width: 48%;
-    text-align: center;
     border: 2px solid transparent;
     box-shadow: $default-shadow;
     cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     @include mobile() {
       width: 100%;

--- a/apps/redi-talent-pool/src/pages/front/signup/SignUpLanding.scss
+++ b/apps/redi-talent-pool/src/pages/front/signup/SignUpLanding.scss
@@ -36,10 +36,6 @@
   }
 }
 
-.signup__type svg{
-  display:inline;
-}
-
 .no-shadow {
   box-shadow: none;
 }

--- a/apps/redi-talent-pool/src/pages/front/signup/SignUpLanding.scss
+++ b/apps/redi-talent-pool/src/pages/front/signup/SignUpLanding.scss
@@ -34,6 +34,10 @@
   }
 }
 
+.signup__type svg{
+  display:inline;
+}
+
 .no-shadow {
   box-shadow: none;
 }


### PR DESCRIPTION

## What Github issue does this PR relate to? Insert link.
Closes https://github.com/talent-connect/connect/issues/961

## What should the reviewer know?
I adding padding to heading "CV BUILDER" - let me know if it placement looks right or needs further adjustment

![image](https://github.com/user-attachments/assets/92758b56-e8fc-439e-8994-a98338fb0c48)
![image](https://github.com/user-attachments/assets/6688a46a-5319-41c6-a560-95d29e8ddfb3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Improved visual spacing above the heading in the CV List page for enhanced layout and readability.
	- Enhanced layout of the signup landing page by adopting a flexbox layout for better alignment and organization of elements.
	- Ensured SVG icons within the signup landing page display inline with surrounding text for improved visual coherence.
	- Updated the CV Builder page to improve semantic hierarchy and mobile responsiveness, enhancing overall user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->