### PR TITLE
Revert "Fix(tp): correct location text on jobseeker profile card and validation message for place of residence (state)* input field"

### DIFF
--- a/apps/redi-connect/src/components/organisms/MentorProfileCard.tsx
+++ b/apps/redi-connect/src/components/organisms/MentorProfileCard.tsx
@@ -29,7 +29,7 @@ export function MentorProfileCard({
     categories,
   } = mentorProfile
   const tags = categories.map((category) => CATEGORIES_MAP[category])
-  const location = `ReDI ${REDI_LOCATION_NAMES[rediLocation]}`
+  const location = REDI_LOCATION_NAMES[rediLocation]
   const avatar = profileAvatarImageS3Key || placeholderImage
 
   return (

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.generated.ts
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.generated.ts
@@ -1,7 +1,7 @@
 // THIS FILE IS GENERATED, DO NOT EDIT!
 import * as Types from '@talent-connect/data-access';
 
-export type JobseekerProfileCardJobseekerProfilePropFragment = { __typename?: 'TpJobseekerDirectoryEntry', id: string, fullName: string, desiredPositions?: Array<Types.TpDesiredPosition> | null, topSkills?: Array<Types.TpTechnicalSkill> | null, profileAvatarImageS3Key?: string | null, federalState?: Types.FederalState | null, workingLanguages?: Array<{ __typename?: 'TpJobseekerProfileLanguageRecord', language: Types.Language }> | null };
+export type JobseekerProfileCardJobseekerProfilePropFragment = { __typename?: 'TpJobseekerDirectoryEntry', id: string, fullName: string, desiredPositions?: Array<Types.TpDesiredPosition> | null, topSkills?: Array<Types.TpTechnicalSkill> | null, profileAvatarImageS3Key?: string | null, location?: string | null, workingLanguages?: Array<{ __typename?: 'TpJobseekerProfileLanguageRecord', language: Types.Language }> | null };
 
 export const JobseekerProfileCardJobseekerProfilePropFragmentDoc = `
     fragment JobseekerProfileCardJobseekerProfileProp on TpJobseekerDirectoryEntry {
@@ -10,7 +10,7 @@ export const JobseekerProfileCardJobseekerProfilePropFragmentDoc = `
   desiredPositions
   topSkills
   profileAvatarImageS3Key
-  federalState
+  location
   workingLanguages {
     language
   }

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.graphql
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.graphql
@@ -4,7 +4,7 @@ fragment JobseekerProfileCardJobseekerProfileProp on TpJobseekerDirectoryEntry {
   desiredPositions
   topSkills
   profileAvatarImageS3Key
-  federalState
+  location
   workingLanguages {
     language
   }

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
@@ -6,7 +6,6 @@ import { NewProfileCard } from '../../../../../libs/shared-atomic-design-compone
 import placeholderImage from '../../assets/img-placeholder.png'
 import { JobseekerProfileCardJobseekerProfilePropFragment } from './JobseekerProfileCard.generated'
 import './JobseekerProfileCard.scss'
-import { germanFederalStates } from '@talent-connect/talent-pool/config'
 
 interface JobseekerProfileCardProps {
   jobseekerProfile: JobseekerProfileCardJobseekerProfilePropFragment
@@ -26,7 +25,7 @@ export function JobseekerProfileCard({
     profileAvatarImageS3Key,
     fullName,
     desiredPositions,
-    federalState,
+    location,
     workingLanguages,
     topSkills,
   } = jobseekerProfile
@@ -38,7 +37,6 @@ export function JobseekerProfileCard({
   const languages = workingLanguages?.map(({ language }) => language)
   const tags = topSkills?.map((skill) => topSkillsIdToLabelMap[skill])
   const avatar = profileAvatarImageS3Key || placeholderImage
-  const location = `Based in ${germanFederalStates[federalState]}`
 
   return (
     <div className="jobSeeker-profile-card-wrapper">

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableNamePhotoLocation.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableNamePhotoLocation.tsx
@@ -132,8 +132,8 @@ const validationSchema = Yup.object({
   lastName: Yup.string()
     .transform(toPascalCaseAndTrim)
     .required('Your last name is required'),
-  location: Yup.string().ensure().required('Your location is required'),
-  federalState: Yup.mixed().required('Please select the state you live in'),
+  location: Yup.string().required('Your location is required'),
+  federalState: Yup.string().required('Please select the state you live in'),
 })
 
 function ModalForm({

--- a/libs/shared-atomic-design-components/src/lib/molecules/NewProfileCard.tsx
+++ b/libs/shared-atomic-design-components/src/lib/molecules/NewProfileCard.tsx
@@ -33,7 +33,7 @@ const UserLocation = ({ location }) => {
         alt="Location"
         className="new-profile-card__location-icon"
       />
-      <p className="new-profile-card__location-text">{location}</p>
+      <p className="new-profile-card__location-text">ReDI {location}</p>
     </div>
   )
 }


### PR DESCRIPTION
Reverts talent-connect/connect#965

We didn't check that beforehand, and apparently, there are around 200 TP users with no `federalState` selected. So, they get `undefined` on the card. 
<img width="1188" alt="image" src="https://github.com/user-attachments/assets/a751958e-2c9d-4932-a42d-3e2ab3271867">

Also, there are some people who are based outside of Germany and have no `federalState` selected.
<img width="755" alt="image" src="https://github.com/user-attachments/assets/c09fa60e-117b-40a2-aa25-28fad74db813">

I am reverting this PR until we decide how we're going to fix that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Jobseeker profiles now display a simplified location instead of federal state information, enhancing clarity and relevance for job matching.
	- The Mentor Profile Card has been updated to present location information without a static prefix.

- **Bug Fixes**
	- Validation for location and federal state fields has been streamlined to ensure they are treated as required strings.

- **Documentation**
	- Adjustments made to the user interface to improve the representation of location information in various components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->