### PR TITLE
Fix(tp): correct location text on jobseeker profile card and validation message for place of residence (state)* input field

### DIFF
--- a/apps/redi-connect/src/components/organisms/MentorProfileCard.tsx
+++ b/apps/redi-connect/src/components/organisms/MentorProfileCard.tsx
@@ -29,7 +29,7 @@ export function MentorProfileCard({
     categories,
   } = mentorProfile
   const tags = categories.map((category) => CATEGORIES_MAP[category])
-  const location = REDI_LOCATION_NAMES[rediLocation]
+  const location = `ReDI ${REDI_LOCATION_NAMES[rediLocation]}`
   const avatar = profileAvatarImageS3Key || placeholderImage
 
   return (

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.generated.ts
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.generated.ts
@@ -1,7 +1,7 @@
 // THIS FILE IS GENERATED, DO NOT EDIT!
 import * as Types from '@talent-connect/data-access';
 
-export type JobseekerProfileCardJobseekerProfilePropFragment = { __typename?: 'TpJobseekerDirectoryEntry', id: string, fullName: string, desiredPositions?: Array<Types.TpDesiredPosition> | null, topSkills?: Array<Types.TpTechnicalSkill> | null, profileAvatarImageS3Key?: string | null, location?: string | null, workingLanguages?: Array<{ __typename?: 'TpJobseekerProfileLanguageRecord', language: Types.Language }> | null };
+export type JobseekerProfileCardJobseekerProfilePropFragment = { __typename?: 'TpJobseekerDirectoryEntry', id: string, fullName: string, desiredPositions?: Array<Types.TpDesiredPosition> | null, topSkills?: Array<Types.TpTechnicalSkill> | null, profileAvatarImageS3Key?: string | null, federalState?: Types.FederalState | null, workingLanguages?: Array<{ __typename?: 'TpJobseekerProfileLanguageRecord', language: Types.Language }> | null };
 
 export const JobseekerProfileCardJobseekerProfilePropFragmentDoc = `
     fragment JobseekerProfileCardJobseekerProfileProp on TpJobseekerDirectoryEntry {
@@ -10,7 +10,7 @@ export const JobseekerProfileCardJobseekerProfilePropFragmentDoc = `
   desiredPositions
   topSkills
   profileAvatarImageS3Key
-  location
+  federalState
   workingLanguages {
     language
   }

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.graphql
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.graphql
@@ -4,7 +4,7 @@ fragment JobseekerProfileCardJobseekerProfileProp on TpJobseekerDirectoryEntry {
   desiredPositions
   topSkills
   profileAvatarImageS3Key
-  location
+  federalState
   workingLanguages {
     language
   }

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
@@ -1,12 +1,12 @@
 import {
   desiredPositionsIdToLabelMap,
+  germanFederalStates,
   topSkillsIdToLabelMap,
 } from '@talent-connect/talent-pool/config'
 import { NewProfileCard } from '../../../../../libs/shared-atomic-design-components/src/lib/molecules/NewProfileCard'
 import placeholderImage from '../../assets/img-placeholder.png'
 import { JobseekerProfileCardJobseekerProfilePropFragment } from './JobseekerProfileCard.generated'
 import './JobseekerProfileCard.scss'
-import { germanFederalStates } from '@talent-connect/talent-pool/config'
 
 interface JobseekerProfileCardProps {
   jobseekerProfile: JobseekerProfileCardJobseekerProfilePropFragment
@@ -38,7 +38,10 @@ export function JobseekerProfileCard({
   const languages = workingLanguages?.map(({ language }) => language)
   const tags = topSkills?.map((skill) => topSkillsIdToLabelMap[skill])
   const avatar = profileAvatarImageS3Key || placeholderImage
-  const location = `Based in ${germanFederalStates[federalState]}`
+  const location =
+    germanFederalStates[federalState] === 'Outside Germany'
+      ? 'Based outside Germany'
+      : `Based in ${germanFederalStates[federalState]}`
 
   return (
     <div className="jobSeeker-profile-card-wrapper">

--- a/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/JobseekerProfileCard.tsx
@@ -6,6 +6,7 @@ import { NewProfileCard } from '../../../../../libs/shared-atomic-design-compone
 import placeholderImage from '../../assets/img-placeholder.png'
 import { JobseekerProfileCardJobseekerProfilePropFragment } from './JobseekerProfileCard.generated'
 import './JobseekerProfileCard.scss'
+import { germanFederalStates } from '@talent-connect/talent-pool/config'
 
 interface JobseekerProfileCardProps {
   jobseekerProfile: JobseekerProfileCardJobseekerProfilePropFragment
@@ -25,7 +26,7 @@ export function JobseekerProfileCard({
     profileAvatarImageS3Key,
     fullName,
     desiredPositions,
-    location,
+    federalState,
     workingLanguages,
     topSkills,
   } = jobseekerProfile
@@ -37,6 +38,7 @@ export function JobseekerProfileCard({
   const languages = workingLanguages?.map(({ language }) => language)
   const tags = topSkills?.map((skill) => topSkillsIdToLabelMap[skill])
   const avatar = profileAvatarImageS3Key || placeholderImage
+  const location = `Based in ${germanFederalStates[federalState]}`
 
   return (
     <div className="jobSeeker-profile-card-wrapper">

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableNamePhotoLocation.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableNamePhotoLocation.tsx
@@ -132,8 +132,8 @@ const validationSchema = Yup.object({
   lastName: Yup.string()
     .transform(toPascalCaseAndTrim)
     .required('Your last name is required'),
-  location: Yup.string().required('Your location is required'),
-  federalState: Yup.string().required('Please select the state you live in'),
+  location: Yup.string().ensure().required('Your location is required'),
+  federalState: Yup.mixed().required('Please select the state you live in'),
 })
 
 function ModalForm({

--- a/libs/shared-atomic-design-components/src/lib/molecules/NewProfileCard.tsx
+++ b/libs/shared-atomic-design-components/src/lib/molecules/NewProfileCard.tsx
@@ -33,7 +33,7 @@ const UserLocation = ({ location }) => {
         alt="Location"
         className="new-profile-card__location-icon"
       />
-      <p className="new-profile-card__location-text">ReDI {location}</p>
+      <p className="new-profile-card__location-text">{location}</p>
     </div>
   )
 }


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Closes https://github.com/talent-connect/connect/issues/962

## What should the reviewer know?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `MentorProfileCard` to display location with a "ReDI" prefix.
	- Introduced `federalState` in the `JobseekerProfileCard` to enhance geographical representation.
  
- **Bug Fixes**
	- Improved validation for `location` and `federalState` fields for better data integrity.

- **Style**
	- Adjusted displayed text in `NewProfileCard` to present location without the "ReDI" prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->