### PR TITLE
fix(con/tp) add the 'no search results' message to the pages with filtering

### DIFF
--- a/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
+++ b/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
@@ -38,7 +38,6 @@ import {
 import { paginateItems } from '@talent-connect/shared-utils'
 import { MentorProfileCard } from '../../../components/organisms/MentorProfileCard'
 import { LoggedIn } from '../../../components/templates'
-import { useLoading } from '../../../hooks/WithLoading'
 import { getAccessTokenFromLocalStorage } from '../../../services/auth/auth'
 import './FindAMentor.scss'
 import { toggleValueInArray } from './utils'
@@ -83,7 +82,6 @@ const FindAMentor = () => {
   const favoriteMentorMutation = useFavoriteMentorMutation()
   const unfavoriteMentorMutation = useUnfavoriteMentorMutation()
 
-  const { Loading, isLoading } = useLoading()
   const history = useHistory()
   const profile = myProfileQuery.data?.conProfile
 
@@ -209,7 +207,7 @@ const FindAMentor = () => {
     history.replace(`/app/mentorships/${matchId}`)
   }
 
-  const mentors = mentorsQuery.data?.conProfilesAvailableMentors
+  const filteredMentorProfiles = mentorsQuery.data?.conProfilesAvailableMentors
     // This logic filters away mentors that have have opted out of being
     // receiving application form mentees from other locations
     .filter(
@@ -221,7 +219,7 @@ const FindAMentor = () => {
     .filter((mentor) => (onlyFavorites ? isMentorFavorite(mentor.id) : true))
 
   const { currentItems, totalItems, totalPagesNumber } = paginateItems({
-    items: mentors ?? [],
+    items: filteredMentorProfiles ?? [],
     currentPageNumber,
     itemsPerPage: MENTOR_CARDS_PER_PAGE,
   })
@@ -229,7 +227,7 @@ const FindAMentor = () => {
   return (
     <LoggedIn>
       <Heading subtitle size="small" className="oneandhalf-bs">
-        Available mentors {mentors?.length ? `(${mentors.length})` : ''}
+        Available mentors {totalItems ? `(${totalItems})` : ''}
       </Heading>
       <div className="filters">
         <div className="filters-inner">
@@ -330,41 +328,40 @@ const FindAMentor = () => {
           </>
         )}
       </div>
-
-      <Columns>
-        {currentItems.map((mentor) => (
-          <Columns.Column
-            mobile={{ size: 12 }}
-            tablet={{ size: 6 }}
-            desktop={{ size: 4 }}
-            key={mentor.id}
-          >
-            <MentorProfileCard
-              mentorProfile={mentor}
-              linkTo={`/app/find-a-mentor/profile/${mentor.id}`}
-              toggleFavorite={() => toggleFavorite(mentor.id)}
-              isFavorite={isMentorFavorite(mentor.id)}
-            />
-          </Columns.Column>
-        ))}
-      </Columns>
-      {totalItems > MENTOR_CARDS_PER_PAGE && (
-        <Pagination
-          totalPagesNumber={totalPagesNumber}
-          currentPageNumber={currentPageNumber}
-          setCurrentPageNumber={setCurrentPageNumber}
-          scrollPosition={PAGINATION_SCROLL_POSITION}
-        />
-      )}
-
-      {mentors?.length === 0 && !isLoading && (
+      {filteredMentorProfiles?.length === 0 ? (
         <Content>
-          <>
-            Unfortunately <strong>couldn't find any mentors</strong> matching
-            your search criteria. You can try adjusting your filters to find
-            more profiles.
-          </>
+          Unfortunately <strong>couldn't find any mentors</strong> matching your
+          search criteria. You can try adjusting your filters to find more
+          profiles.
         </Content>
+      ) : (
+        <>
+          <Columns>
+            {currentItems.map((mentor) => (
+              <Columns.Column
+                mobile={{ size: 12 }}
+                tablet={{ size: 6 }}
+                desktop={{ size: 4 }}
+                key={mentor.id}
+              >
+                <MentorProfileCard
+                  mentorProfile={mentor}
+                  linkTo={`/app/find-a-mentor/profile/${mentor.id}`}
+                  toggleFavorite={() => toggleFavorite(mentor.id)}
+                  isFavorite={isMentorFavorite(mentor.id)}
+                />
+              </Columns.Column>
+            ))}
+          </Columns>
+          {totalItems > MENTOR_CARDS_PER_PAGE && (
+            <Pagination
+              totalPagesNumber={totalPagesNumber}
+              currentPageNumber={currentPageNumber}
+              setCurrentPageNumber={setCurrentPageNumber}
+              scrollPosition={PAGINATION_SCROLL_POSITION}
+            />
+          )}
+        </>
       )}
     </LoggedIn>
   )

--- a/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
+++ b/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
@@ -330,9 +330,9 @@ const FindAMentor = () => {
       </div>
       {filteredMentorProfiles?.length === 0 ? (
         <Content>
-          Unfortunately <strong>couldn't find any mentors</strong> matching your
-          search criteria. You can try adjusting your filters to find more
-          profiles.
+          Unfortunately <strong>couldn't find any mentor profiles</strong>{' '}
+          matching your search criteria. You can try adjusting your filters to
+          find more profiles.
         </Content>
       ) : (
         <>

--- a/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
+++ b/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
@@ -360,8 +360,9 @@ const FindAMentor = () => {
       {mentors?.length === 0 && !isLoading && (
         <Content>
           <>
-            Unfortunately <strong>could not find any mentors</strong> matching
-            your search criterias.
+            Unfortunately <strong>couldn't find any mentors</strong> matching
+            your search criteria. You can try adjusting your filters to find
+            more profiles.
           </>
         </Content>
       )}

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -399,42 +399,42 @@ export function BrowseCompany() {
           </>
         )}
       </div>
-      <Columns>
-        {currentItems.map((profile) => (
-          <Columns.Column
-            key={profile.id}
-            mobile={{ size: 12 }}
-            tablet={{ size: 6 }}
-            desktop={{ size: 4 }}
-          >
-            <JobseekerProfileCard
-              key={profile.id}
-              jobseekerProfile={profile}
-              linkTo={`/app/jobseeker-profile/${profile.id}`}
-              toggleFavorite={handleFavoriteJobseeker}
-              isFavorite={isJobseekerFavorite(profile.id)}
-            />
-          </Columns.Column>
-        ))}
-      </Columns>
-      {totalItems > JOBSEEKER_CARDS_PER_PAGE && (
-        <Pagination
-          totalPagesNumber={totalPagesNumber}
-          currentPageNumber={currentPageNumber}
-          setCurrentPageNumber={setCurrentPageNumber}
-          scrollPosition={PAGINATION_SCROLL_POSITION}
-        />
-      )}
-
-      {filteredJobseekerProfiles?.length === 0 && (
+      {filteredJobseekerProfiles?.length === 0 ? (
         <Content>
-          <>
-            Unfortunately, we{' '}
-            <strong>couldn't find any jobseeker profiles</strong> matching your
-            search criteria. You can try adjusting your filters to find more
-            profiles.
-          </>
+          Unfortunately, we{' '}
+          <strong>couldn't find any jobseeker profiles</strong> matching your
+          search criteria. You can try adjusting your filters to find more
+          profiles.
         </Content>
+      ) : (
+        <>
+          <Columns>
+            {currentItems.map((profile) => (
+              <Columns.Column
+                key={profile.id}
+                mobile={{ size: 12 }}
+                tablet={{ size: 6 }}
+                desktop={{ size: 4 }}
+              >
+                <JobseekerProfileCard
+                  key={profile.id}
+                  jobseekerProfile={profile}
+                  linkTo={`/app/jobseeker-profile/${profile.id}`}
+                  toggleFavorite={handleFavoriteJobseeker}
+                  isFavorite={isJobseekerFavorite(profile.id)}
+                />
+              </Columns.Column>
+            ))}
+          </Columns>
+          {totalItems > JOBSEEKER_CARDS_PER_PAGE && (
+            <Pagination
+              totalPagesNumber={totalPagesNumber}
+              currentPageNumber={currentPageNumber}
+              setCurrentPageNumber={setCurrentPageNumber}
+              scrollPosition={PAGINATION_SCROLL_POSITION}
+            />
+          )}
+        </>
       )}
     </LoggedIn>
   )

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -429,8 +429,10 @@ export function BrowseCompany() {
       {filteredJobseekerProfiles?.length === 0 && (
         <Content>
           <>
-            Unfortunately <strong>could not find any jobseekers</strong>{' '}
-            matching your search criterias.
+            Unfortunately, we{' '}
+            <strong>couldn't find any jobseeker profiles</strong> matching your
+            search criteria. You can try adjusting your filters to find more
+            profiles.
           </>
         </Content>
       )}

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseCompany.tsx
@@ -26,7 +26,7 @@ import {
 } from '@talent-connect/talent-pool/config'
 import { objectEntries } from '@talent-connect/typescript-utilities'
 import { useState } from 'react'
-import { Columns, Element, Tag } from 'react-bulma-components'
+import { Columns, Content, Element, Tag } from 'react-bulma-components'
 import { useQueryClient } from 'react-query'
 import {
   ArrayParam,
@@ -424,6 +424,15 @@ export function BrowseCompany() {
           setCurrentPageNumber={setCurrentPageNumber}
           scrollPosition={PAGINATION_SCROLL_POSITION}
         />
+      )}
+
+      {filteredJobseekerProfiles?.length === 0 && (
+        <Content>
+          <>
+            Unfortunately <strong>could not find any jobseekers</strong>{' '}
+            matching your search criterias.
+          </>
+        </Content>
       )}
     </LoggedIn>
   )

--- a/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
+++ b/apps/redi-talent-pool/src/pages/app/browse/BrowseJobseeker.tsx
@@ -25,7 +25,7 @@ import {
 import { objectEntries } from '@talent-connect/typescript-utilities'
 import { formatDistance } from 'date-fns'
 import { useState } from 'react'
-import { Columns, Element, Tag } from 'react-bulma-components'
+import { Columns, Content, Element, Tag } from 'react-bulma-components'
 import { useQueryClient } from 'react-query'
 import { Redirect } from 'react-router-dom'
 import {
@@ -420,26 +420,34 @@ export function BrowseJobseeker() {
           </>
         )}
       </div>
-      <Columns>
-        {filteredJobListings?.map((jobListing) => (
-          <Columns.Column key={jobListing.id} size={12}>
-            <JobListingCard
-              jobListing={jobListing}
-              linkTo={`/app/job-listing/${jobListing.id}`}
-              renderCTA={() =>
-                renderFavoriteCTA(jobListing.id, isFavorite(jobListing.id))
-              }
-              timestamp={`Last updated ${formatDistance(
-                new Date(jobListing.updatedAt),
-                new Date(),
-                {
-                  addSuffix: true,
+      {filteredJobListings?.length === 0 ? (
+        <Content>
+          Unfortunately, we <strong>couldn't find any job listings</strong>{' '}
+          matching your search criteria. You can try adjusting your filters to
+          find more opportunities.
+        </Content>
+      ) : (
+        <Columns>
+          {filteredJobListings?.map((jobListing) => (
+            <Columns.Column key={jobListing.id} size={12}>
+              <JobListingCard
+                jobListing={jobListing}
+                linkTo={`/app/job-listing/${jobListing.id}`}
+                renderCTA={() =>
+                  renderFavoriteCTA(jobListing.id, isFavorite(jobListing.id))
                 }
-              )}`}
-            />
-          </Columns.Column>
-        ))}
-      </Columns>
+                timestamp={`Last updated ${formatDistance(
+                  new Date(jobListing.updatedAt),
+                  new Date(),
+                  {
+                    addSuffix: true,
+                  }
+                )}`}
+              />
+            </Columns.Column>
+          ))}
+        </Columns>
+      )}
     </LoggedIn>
   )
 }


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

In this PR, I added the 'no search results' messages to the `Browse jobseekers` and `Browse job listing `pages, updated the message's wording on the `Find a Mentor` page, and introduced some code refactoring.

## Screenshots
![image](https://github.com/user-attachments/assets/2fdc4c14-9392-482e-8618-f342ccdd8adb)
![image](https://github.com/user-attachments/assets/d13c9fd0-f9d2-47bf-b4bd-cd60f56acfbe)
![image](https://github.com/user-attachments/assets/96978068-4f93-446d-8d6e-ebf3d7872494)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user feedback with messages when no mentor or jobseeker profiles are found.
	- Introduced a function to filter job listings based on user favorites.

- **Improvements**
	- Streamlined filtering logic for mentor profiles and job listings for better readability and maintainability.
	- Updated rendering logic to ensure correct display of pagination and content based on available profiles.

- **Bug Fixes**
	- Corrected variable naming to accurately reflect the data being displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->