### PR TITLE
feat(con/profile page): mentees with active mentor can't view profile of other mentor

### DIFF
--- a/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
+++ b/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
@@ -2,6 +2,7 @@ import {
   ConnectProfileStatus,
   Language,
   MentoringTopic,
+  MentorshipMatchStatus,
   RediLocation,
   useFavoriteMentorMutation,
   useFindAvailableMentorsQuery,
@@ -200,10 +201,14 @@ const FindAMentor = () => {
   const menteeHasAnActiveMatch =
     profile?.userType === 'MENTEE' &&
     profile?.mentorshipMatches.length > 0 &&
-    profile?.mentorshipMatches?.[0].status === 'ACCEPTED'
+    profile?.mentorshipMatches?.some(match =>
+      match.status === MentorshipMatchStatus.Accepted
+    )
 
   if (menteeHasAnActiveMatch) {
-    const matchId = profile?.mentorshipMatches?.[0].id
+    const matchId = profile?.mentorshipMatches?.find(match =>
+      match.status === MentorshipMatchStatus.Accepted
+    ).id
     history.replace(`/app/mentorships/${matchId}`)
   }
 

--- a/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
+++ b/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
@@ -198,18 +198,16 @@ const FindAMentor = () => {
   if (profile && profile?.profileStatus !== ConnectProfileStatus.Approved)
     return <LoggedIn />
 
-  const menteeHasAnActiveMatch =
-    profile?.userType === 'MENTEE' &&
-    profile?.mentorshipMatches.length > 0 &&
-    profile?.mentorshipMatches?.some(match =>
-      match.status === MentorshipMatchStatus.Accepted
-    )
-
-  if (menteeHasAnActiveMatch) {
-    const activeMentorshipMatch = 
+  const activeMentorshipMatch = 
       profile.mentorshipMatches.find(match =>
         match.status === MentorshipMatchStatus.Accepted
       )
+  const menteeHasAnActiveMatch =
+    profile?.userType === 'MENTEE' &&
+    profile?.mentorshipMatches.length > 0 &&
+    activeMentorshipMatch
+  
+  if (menteeHasAnActiveMatch) {  
     return (
       <LoggedIn>
         <Content>

--- a/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
+++ b/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
@@ -198,26 +198,26 @@ const FindAMentor = () => {
   if (profile && profile?.profileStatus !== ConnectProfileStatus.Approved)
     return <LoggedIn />
 
-  const activeMentorshipMatch = 
-      profile.mentorshipMatches.find(match =>
-        match.status === MentorshipMatchStatus.Accepted
-      )
+  const activeMentorshipMatch = profile?.mentorshipMatches.find(
+    (match) => match.status === MentorshipMatchStatus.Accepted
+  )
   const menteeHasAnActiveMatch =
     profile?.userType === 'MENTEE' &&
     profile?.mentorshipMatches.length > 0 &&
     activeMentorshipMatch
-  
-  if (menteeHasAnActiveMatch) {  
+
+  if (menteeHasAnActiveMatch) {
     return (
       <LoggedIn>
         <Content>
           Hey there! It looks like you already have{' '}
-          <a href={`/app/mentorships/${activeMentorshipMatch?.mentor.id}`}>an ongoing mentorship</a> with
-          another mentor. Please remember that you can only have one mentor at a
-          time. You can save this link to check if this mentor remains available
-          once you complete your current mentorship match. If you have any
-          questions in the meantime, feel free to check out the{' '}
-          <a href="/faq">FAQ</a>.
+          <a href={`/app/mentorships/${activeMentorshipMatch?.mentor.id}`}>
+            an ongoing mentorship
+          </a>{' '}
+          with another mentor. Please remember that you can only have one mentor
+          at a time. You can check available mentors once you complete your
+          current mentorship match. If you have any questions in the meantime,
+          feel free to check out the <a href="/faq">FAQ</a>.
         </Content>
       </LoggedIn>
     )

--- a/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
+++ b/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
@@ -214,7 +214,7 @@ const FindAMentor = () => {
       <LoggedIn>
         <Content>
           Hey there! It looks like you already have{' '}
-          <a href={`/app/mentorships/${activeMentorshipMatch?.mentorId}`}>an ongoing mentorship</a> with
+          <a href={`/app/mentorships/${activeMentorshipMatch?.mentor.id}`}>an ongoing mentorship</a> with
           another mentor. Please remember that you can only have one mentor at a
           time. You can save this link to check if this mentor remains available
           once you complete your current mentorship match. If you have any

--- a/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
+++ b/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
@@ -211,7 +211,7 @@ const FindAMentor = () => {
       <LoggedIn>
         <Content>
           Hey there! It looks like you already have{' '}
-          <a href={`/app/mentorships/${activeMentorshipMatch?.mentor.id}`}>
+          <a href={`/app/mentorships/${activeMentorshipMatch?.id}`}>
             an ongoing mentorship
           </a>{' '}
           with another mentor. Please remember that you can only have one mentor

--- a/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
+++ b/apps/redi-connect/src/pages/app/find-a-mentor/FindAMentor.tsx
@@ -206,10 +206,23 @@ const FindAMentor = () => {
     )
 
   if (menteeHasAnActiveMatch) {
-    const matchId = profile?.mentorshipMatches?.find(match =>
-      match.status === MentorshipMatchStatus.Accepted
-    ).id
-    history.replace(`/app/mentorships/${matchId}`)
+    const activeMentorshipMatch = 
+      profile.mentorshipMatches.find(match =>
+        match.status === MentorshipMatchStatus.Accepted
+      )
+    return (
+      <LoggedIn>
+        <Content>
+          Hey there! It looks like you already have{' '}
+          <a href={`/app/mentorships/${activeMentorshipMatch?.mentorId}`}>an ongoing mentorship</a> with
+          another mentor. Please remember that you can only have one mentor at a
+          time. You can save this link to check if this mentor remains available
+          once you complete your current mentorship match. If you have any
+          questions in the meantime, feel free to check out the{' '}
+          <a href="/faq">FAQ</a>.
+        </Content>
+      </LoggedIn>
+    )
   }
 
   const filteredMentorProfiles = mentorsQuery.data?.conProfilesAvailableMentors

--- a/apps/redi-connect/src/pages/app/profile/Profile.tsx
+++ b/apps/redi-connect/src/pages/app/profile/Profile.tsx
@@ -90,10 +90,9 @@ function Profile() {
 
   const shouldHidePrivateContactInfo = currentUserIsMentee && !isAcceptedMatch
 
-  const activeMentorshipMatch = 
-    myProfile.mentorshipMatches.find(match =>
-      match.status === MentorshipMatchStatus.Accepted
-    )
+  const activeMentorshipMatch = myProfile.mentorshipMatches.find(
+    (match) => match.status === MentorshipMatchStatus.Accepted
+  )
 
   const viewMode = determineViewMode(profile, myProfile)
 
@@ -264,14 +263,16 @@ function Profile() {
     currentUserIsMenteeAndViewsNotTheirMentor: (
       <>
         Hey there! It looks like you already have{' '}
-        <a href={`/app/mentorships/${activeMentorshipMatch?.mentorId}`}>an ongoing mentorship</a> with
-        another mentor. Please remember that you can only have one mentor at a
-        time. You can save this link to check if this mentor remains available
-        once you complete your current mentorship match. If you have any
-        questions in the meantime, feel free to check out the{' '}
+        <a href={`/app/mentorships/${activeMentorshipMatch?.mentorId}`}>
+          an ongoing mentorship
+        </a>{' '}
+        with another mentor. Please remember that you can only have one mentor
+        at a time. You can save this link to check if this mentor remains
+        available once you complete your current mentorship match. If you have
+        any questions in the meantime, feel free to check out the{' '}
         <a href="/faq">FAQ</a>.
       </>
-    )
+    ),
   }
   return (
     <LoggedIn>
@@ -320,9 +321,10 @@ function Profile() {
   )
 }
 
-type ViewMode = 'display'
-  | 'notActivelyMentoring' 
-  | 'mentoringButNoFreeSpots' 
+type ViewMode =
+  | 'display'
+  | 'notActivelyMentoring'
+  | 'mentoringButNoFreeSpots'
   | 'currentUserIsMenteeAndViewsNotTheirMentor'
 
 function determineViewMode(
@@ -331,26 +333,27 @@ function determineViewMode(
 ): ViewMode {
   // If we're looking at a mentee, show the profile. Otherwise, the profile
   // is a mentor's profile, so continue to determine if the view mode is a
-  // "special" one. 
+  // "special" one.
   if (profile.userType === UserType.Mentee) return 'display'
-  
-  const activeMentorshipMatch = 
-    currentUserProfile.mentorshipMatches.find(match =>
-      match.status === MentorshipMatchStatus.Accepted
-    )
+
+  const activeMentorshipMatch = currentUserProfile.mentorshipMatches.find(
+    (match) => match.status === MentorshipMatchStatus.Accepted
+  )
 
   // Is current user a mentee, does that mentee have an active match, and is
   // that match with another mentor than the one we're currently looking at?
-  if (activeMentorshipMatch.mentor.id === currentUserProfile.id) return 'display'
+  if (activeMentorshipMatch.mentorId === currentUserProfile.id) return 'display'
+
+  console.log(activeMentorshipMatch, profile)
 
   if (
     currentUserProfile.userType === UserType.Mentee &&
     activeMentorshipMatch?.status === MentorshipMatchStatus.Accepted &&
-    activeMentorshipMatch?.mentor.id !== profile.userId
+    activeMentorshipMatch?.mentorId !== profile.userId
   ) {
     return 'currentUserIsMenteeAndViewsNotTheirMentor'
   }
-  
+
   if (profile.menteeCountCapacity === 0) return 'notActivelyMentoring'
   if (profile.doesNotHaveAvailableMentorshipSlot)
     return 'mentoringButNoFreeSpots'

--- a/apps/redi-connect/src/pages/app/profile/Profile.tsx
+++ b/apps/redi-connect/src/pages/app/profile/Profile.tsx
@@ -343,7 +343,7 @@ function determineViewMode(
   if (
     currentUserProfile.userType === UserType.Mentee &&
     activeMentorshipMatch?.status === MentorshipMatchStatus.Accepted &&
-    activeMentorshipMatch?.mentorId != activeMentorshipMatch.mentorId
+    activeMentorshipMatch?.mentor.id !== profile.userId
   ) {
     return 'currentUserIsMenteeAndViewsNotTheirMentor'
   }

--- a/apps/redi-connect/src/pages/app/profile/Profile.tsx
+++ b/apps/redi-connect/src/pages/app/profile/Profile.tsx
@@ -263,7 +263,7 @@ function Profile() {
     currentUserIsMenteeAndViewsNotTheirMentor: (
       <>
         Hey there! It looks like you already have{' '}
-        <a href={`/app/mentorships/${activeMentorshipMatch?.mentorId}`}>
+        <a href={`/app/mentorships/${activeMentorshipMatch?.id}`}>
           an ongoing mentorship
         </a>{' '}
         with another mentor. Please remember that you can only have one mentor

--- a/apps/redi-connect/src/pages/app/profile/Profile.tsx
+++ b/apps/redi-connect/src/pages/app/profile/Profile.tsx
@@ -334,12 +334,15 @@ function determineViewMode(
   // "special" one. 
   if (profile.userType === UserType.Mentee) return 'display'
   
-  // Is current user a mentee, does that mentee have an active match, and is
-  // that match with another mentor than the one we're currently looking at?
   const activeMentorshipMatch = 
     currentUserProfile.mentorshipMatches.find(match =>
       match.status === MentorshipMatchStatus.Accepted
     )
+
+  // Is current user a mentee, does that mentee have an active match, and is
+  // that match with another mentor than the one we're currently looking at?
+  if (activeMentorshipMatch.mentor.id === currentUserProfile.id) return 'display'
+
   if (
     currentUserProfile.userType === UserType.Mentee &&
     activeMentorshipMatch?.status === MentorshipMatchStatus.Accepted &&

--- a/apps/redi-connect/src/pages/app/profile/Profile.tsx
+++ b/apps/redi-connect/src/pages/app/profile/Profile.tsx
@@ -267,10 +267,9 @@ function Profile() {
           an ongoing mentorship
         </a>{' '}
         with another mentor. Please remember that you can only have one mentor
-        at a time. You can save this link to check if this mentor remains
-        available once you complete your current mentorship match. If you have
-        any questions in the meantime, feel free to check out the{' '}
-        <a href="/faq">FAQ</a>.
+        at a time. You can check available mentors once you complete your
+        current mentorship match. If you have any questions in the meantime,
+        feel free to check out the <a href="/faq">FAQ</a>.
       </>
     ),
   }


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

Closes #982 

## What should the reviewer know?

This PR implements a quick solution to add further restrictions to mentees visiting the profile page of a mentor. Besides the two existing restrictions (mentor isn't actively mentoring, or mentor has no free mentoring spots), we add a third one: mentees with an active mentor/mentorship can't view the profile of another mentor.

**NOTE: PR implemented while travelling on a laptop without working dev environment - please test the implementation and error-free build**:
1. Log in as a mentee in an active mentorship
2. Access the profile page `/app/find-a-mentor/profile/:profileId` of a mentor
3. Confirm that an overlay is shown
4. Confirm that the _an ongoing mentorship_ link leads to the dashboard of the current mentorship

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced mentorship match status checks for improved accuracy.
	- Introduced new user feedback messages based on mentorship status.
	- Added nuanced view mode for users viewing mentor profiles.

- **Bug Fixes**
	- Improved logic for determining the most recent accepted mentorship match.

- **Documentation**
	- Updated rendering logic for clearer user guidance regarding mentorship relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->