### PR TITLE
Feat/con/link mentoring session to parent match

### DIFF
--- a/apps/nestjs-api/src/salesforce-api/sf-api-con-mentoring-sessions.service.ts
+++ b/apps/nestjs-api/src/salesforce-api/sf-api-con-mentoring-sessions.service.ts
@@ -31,6 +31,7 @@ export class SfApiConMentoringSessionsService {
       'Durations_in_Minutes__c',
       'Mentor__c',
       'Mentee__c',
+      'Mentorship_Match__c',
     ])
 
     const createResult = await this.repository.createRecord(

--- a/apps/redi-connect/src/components/organisms/modules/MSessions.tsx
+++ b/apps/redi-connect/src/components/organisms/modules/MSessions.tsx
@@ -65,9 +65,15 @@ interface MSessions {
   sessions: Pick<ConMentoringSession, 'id' | 'date' | 'minuteDuration'>[]
   menteeId: string
   editable?: boolean
+  mentorshipMatchId: string
 }
 
-const MSessions = ({ sessions, menteeId, editable }: MSessions) => {
+const MSessions = ({
+  sessions,
+  menteeId,
+  editable,
+  mentorshipMatchId,
+}: MSessions) => {
   const queryClient = useQueryClient()
   const { matchId } = useParams<MentorshipRouteParams>()
   const createSessionMutation = useCreateMentoringSessionMutation()
@@ -82,6 +88,7 @@ const MSessions = ({ sessions, menteeId, editable }: MSessions) => {
       input: {
         ...values,
         menteeId,
+        mentorshipMatchId,
       },
     })
     // TODO: I don't like this dependency - this mutation has to know which queries

--- a/apps/redi-connect/src/pages/app/mentorship/Mentorship.tsx
+++ b/apps/redi-connect/src/pages/app/mentorship/Mentorship.tsx
@@ -102,6 +102,7 @@ function Mentorship() {
             sessions={viewMatch.mentoringSessions}
             menteeId={viewProfile.userId}
             editable={currentUserIsMentor}
+            mentorshipMatchId={matchId}
           />
           <ReportProblem
             type={myProfile.userType}

--- a/libs/common-types/src/lib/con-mentoring-session/con-mentoring-session.entityprops.ts
+++ b/libs/common-types/src/lib/con-mentoring-session/con-mentoring-session.entityprops.ts
@@ -15,6 +15,8 @@ export class ConMentoringSessionEntityProps implements EntityProps {
   mentorId: string
   @Field((type) => ID)
   menteeId: string
+  @Field((type) => ID)
+  mentorshipMatchId: string
 
   createdAt: Date
   updatedAt: Date

--- a/libs/common-types/src/lib/con-mentoring-session/con-mentoring-session.mapper.ts
+++ b/libs/common-types/src/lib/con-mentoring-session/con-mentoring-session.mapper.ts
@@ -24,6 +24,7 @@ export class ConMentoringSessionMapper
       ]
     props.mentorId = raw.props.Mentor__c
     props.menteeId = raw.props.Mentee__c
+    props.mentorshipMatchId = raw.props.Mentorship_Match__c
     props.createdAt = raw.props.CreatedDate
     props.updatedAt = raw.props.LastModifiedDate
 
@@ -43,6 +44,7 @@ export class ConMentoringSessionMapper
     )
     props.Mentor__c = srcProps.mentorId
     props.Mentee__c = srcProps.menteeId
+    props.Mentorship_Match__c = srcProps.mentorshipMatchId
 
     const record = ConMentoringSessionRecord.create(props)
 

--- a/libs/common-types/src/lib/con-mentoring-session/con-mentoring-session.record.ts
+++ b/libs/common-types/src/lib/con-mentoring-session/con-mentoring-session.record.ts
@@ -21,6 +21,7 @@ export class ConMentoringSessionRecord extends Record<ConMentoringSessionRecordP
       'Durations_in_Minutes__c',
       'Mentee__c',
       'Mentor__c',
+      'Mentorship_Match__c',
       'CreatedDate',
       'LastModifiedDate',
     ],

--- a/libs/common-types/src/lib/con-mentoring-session/con-mentoring-session.recordprops.ts
+++ b/libs/common-types/src/lib/con-mentoring-session/con-mentoring-session.recordprops.ts
@@ -10,6 +10,7 @@ export class ConMentoringSessionRecordProps implements RecordProps {
 
   Mentor__c: string
   Mentee__c: string
+  Mentorship_Match__c: string
 
   @Type(() => Date)
   CreatedDate: Date

--- a/libs/common-types/src/lib/con-mentoring-session/entity-dtos/create-con-mentoring-session.entityinput.ts
+++ b/libs/common-types/src/lib/con-mentoring-session/entity-dtos/create-con-mentoring-session.entityinput.ts
@@ -1,10 +1,4 @@
-import {
-  Field,
-  InputType,
-  PartialType,
-  PickType,
-  IntersectionType,
-} from '@nestjs/graphql'
+import { InputType, PickType } from '@nestjs/graphql'
 import { ConMentoringSessionEntityProps } from '../con-mentoring-session.entityprops'
 
 @InputType()
@@ -13,5 +7,5 @@ class _ConMentoringSessionntityProps extends ConMentoringSessionEntityProps {}
 @InputType('CreateConMentoringSessionInput')
 export class CreateConMentoringSessionInput extends PickType(
   _ConMentoringSessionntityProps,
-  ['date', 'minuteDuration', 'menteeId'] as const
+  ['date', 'minuteDuration', 'menteeId', 'mentorshipMatchId'] as const
 ) {}

--- a/libs/data-access/src/lib/types/types.ts
+++ b/libs/data-access/src/lib/types/types.ts
@@ -55,6 +55,7 @@ export type ConMentoringSession = {
   id: Scalars['ID'];
   menteeId: Scalars['ID'];
   mentorId: Scalars['ID'];
+  mentorshipMatchId: Scalars['ID'];
   minuteDuration: MentoringSessionDuration;
   updatedAt: Scalars['DateTime'];
 };
@@ -193,6 +194,7 @@ export enum ConnectProfileStatus {
 export type CreateConMentoringSessionInput = {
   date: Scalars['DateTime'];
   menteeId: Scalars['ID'];
+  mentorshipMatchId: Scalars['ID'];
   minuteDuration: MentoringSessionDuration;
 };
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -34,6 +34,7 @@ type ConMentoringSession {
   id: ID!
   menteeId: ID!
   mentorId: ID!
+  mentorshipMatchId: ID!
   minuteDuration: MentoringSessionDuration!
   updatedAt: DateTime!
 }
@@ -166,6 +167,7 @@ enum ConnectProfileStatus {
 input CreateConMentoringSessionInput {
   date: DateTime!
   menteeId: ID!
+  mentorshipMatchId: ID!
   minuteDuration: MentoringSessionDuration!
 }
 


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

#949 

## What should the reviewer know?

This PR makes use of the new `Mentorship_Match__c` field on `Mentoring Session` records in Salesforce when sessions are logged.

When a mentoring session is logged, it's always been linked to a `Mentor` and a `Mentee`. With this PR, sessions will also be linked to a parent `Mentorship Match`.

The query that loads mentoring sessions and display them on the "Mentorship Dashboard" page, as seen here ...

![CleanShot 2024-10-28 at 22 32 53](https://github.com/user-attachments/assets/d7d72e25-9c32-45df-934a-367d2f8a235f)

... was _not_ updated, since it lets the mentor and mentee see their entire history of logged sessions, even if they have more than one match (e.g. a completed one and a currently active one.

The other tasks that are part of #949 will be taken care of on deployment to production:
- [ ] Run this APEX script to ensure all Mentoring Sessions are linked to a Mentorship Match
```
// Query all Mentoring_Session__c records
List<Mentoring_Session__c> sessionsToUpdate = [SELECT Id, Mentee__c, Mentor__c FROM Mentoring_Session__c];

// Create a list to hold the records that need to be updated
List<Mentoring_Session__c> recordsToUpdate = new List<Mentoring_Session__c>();

// Create a list to log cases where no Mentorship_Match__c is found
List<String> noMatchFoundLogs = new List<String>();

// Create a map to store Mentorship_Match__c records by Mentee__c and Mentor__c
Map<String, Mentorship_Match__c> mentorshipMatchMap = new Map<String, Mentorship_Match__c>();

// Build a set of keys to query the Mentorship_Match__c records
Set<String> sessionKeys = new Set<String>();
Set<String> allMentorIds = new Set<String>();
Set<String> allMenteeIds = new Set<String>();
for (Mentoring_Session__c session : sessionsToUpdate) {
//    String key = session.Mentee__c + '-' + session.Mentor__c; // abc-def Mentee-Mentor
//    sessionKeys.add(key);

        allMentorIds.add(session.Mentor__c);
        allMenteeIds.add(session.Mentee__c);
}

// Query all Mentorship_Match__c records that match the session keys
List<Mentorship_Match__c> allMatches = [SELECT Id, Mentee__c, Mentor__c FROM Mentorship_Match__c WHERE Mentee__c IN :allMenteeIds AND Mentor__c IN :allMentorIds];
for (Mentorship_Match__c match : allMatches) {
    String key = match.Mentee__c + '-' + match.Mentor__c;
    mentorshipMatchMap.put(key, match);
}

// Iterate over each mentoring session record
for (Mentoring_Session__c session : sessionsToUpdate) {
    String key = session.Mentee__c + '-' + session.Mentor__c;
    if (mentorshipMatchMap.containsKey(key)) {
        // Update the Mentorship_Match__c field with the found match's ID
        session.Mentorship_Match__c = mentorshipMatchMap.get(key).Id;
        recordsToUpdate.add(session);
    } else {
        // Log the case where no match is found
        noMatchFoundLogs.add('No match found for Mentoring Session ID: ' + session.Id + ' with Mentee__c: ' + session.Mentee__c + ' and Mentor__c: ' + session.Mentor__c);
    }
}

// Update the records in the database
if (!recordsToUpdate.isEmpty()) {
    update recordsToUpdate;
}

// Log all cases of no Mentorship_Match__c found
for (String log : noMatchFoundLogs) {
    System.debug(log);
}
```

- [ ] Update Mentoring Session object to have a Master-Detail relationship to Mentorship Math object, on production, contpdemo, and partialsbx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `mentorshipMatchId` to enhance the data flow in mentoring sessions, linking them directly to mentorship matches.
  - Updated forms and components to include the new `mentorshipMatchId` property during session creation.

- **Bug Fixes**
  - Improved data handling for mentorship session creation by incorporating the `Mentorship_Match__c` field.

- **Documentation**
  - Updated GraphQL schema to reflect the addition of `mentorshipMatchId` in relevant types and input structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->