### PR TITLE
fix(con): add maxLength for the expectations field of the profile

### DIFF
--- a/apps/redi-connect/src/components/organisms/EditableAbout.tsx
+++ b/apps/redi-connect/src/components/organisms/EditableAbout.tsx
@@ -86,6 +86,7 @@ function EditableAbout() {
         name="expectations"
         rows={4}
         placeholder={expectationsFieldPlaceholder(userType)}
+        maxLength={MAX_CHARS_COUNT}
         formik={formik}
       />
     </Editable>
@@ -95,10 +96,10 @@ function EditableAbout() {
 const expectationsFieldLabel = (userType: UserType): string => {
   switch (userType) {
     case 'MENTEE':
-      return 'What do you expect from a mentorship and which short- to medium-term goals would you like to achieve in about 5-6 mentoring sessions?'
+      return 'What do you expect from a mentorship and which short- to medium-term goals would you like to achieve in about 5-6 mentoring sessions? (max 600 characters)'
 
     case 'MENTOR':
-      return 'Feel free to share how you can best support your mentees and any expectations you may have towards them'
+      return 'Feel free to share how you can best support your mentees and any expectations you may have towards them (max 600 characters)'
 
     default:
       return null


### PR DESCRIPTION
## What Github issue does this PR relate to? Insert link.

No issue.

## What should the reviewer know?

In Salesforce, the `Expectations` field in the `ReDI Connect profile` object has the maximum length set to 1000 characters. Currently, when users attempt to enter more than 1000 characters, they are unable to save that section of the profile and see no validation error because the maximum length for that field hasn't been set in the codebase. 

In this PR, we add the `maxLength` property to the `Expectations` field, setting the maximum number of characters allowed and notifying users accordingly.

## Screenshots

<img width="668" alt="image" src="https://github.com/user-attachments/assets/e83280ac-c9b8-4c9d-89c8-afbbe7946949" />

