### PR TITLE
migrate from react-beautiful-dnd to dnd-kit

### DIFF
--- a/apps/redi-talent-pool/src/components/molecules/SortableItem.tsx
+++ b/apps/redi-talent-pool/src/components/molecules/SortableItem.tsx
@@ -1,0 +1,23 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+interface SortableItemProps {
+  id: string
+  children: JSX.Element
+}
+
+export function SortableItem({ id, children }: SortableItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {children}
+    </div>
+  )
+}

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-cv-editables/AccordionFormCvEducation.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-cv-editables/AccordionFormCvEducation.tsx
@@ -1,4 +1,15 @@
 import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import {
   TpJobseekerCvEducationRecord,
   useFindAllTpJobseekerCvEducationRecordsQuery,
   useTpJobseekerCvEducationRecordCreateMutation,
@@ -22,7 +33,6 @@ import { reorder } from '@talent-connect/typescript-utilities'
 import { useFormik } from 'formik'
 import { cloneDeep } from 'lodash'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
-import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd'
 import { Columns, Element } from 'react-bulma-components'
 import { useQueryClient } from 'react-query'
 import { Subject } from 'rxjs'
@@ -30,6 +40,7 @@ import { v4 as uuidv4 } from 'uuid'
 import * as Yup from 'yup'
 import { useIsBusy } from '../../../hooks/useIsBusy'
 import { AccordionForm } from '../../molecules/AccordionForm'
+import { SortableItem } from '../../molecules/SortableItem'
 interface Props {
   tpJobseekerCvId: string
   onClose: () => void
@@ -269,13 +280,25 @@ function JobseekerFormSectionEducation({
   }, [formik])
 
   const onDragEnd = useCallback(
-    (result: any) => {
-      if (!result.destination) return
+    ({ active, over }: DragEndEvent) => {
+      if (!over || active.id === over.id) return
+
+      const activeId = active.id.toString()
+      const overId = over.id.toString()
+
+      const sourceIndex = formik.values.education.findIndex(
+        (record) => record.id === activeId
+      )
+      const destinationIndex = formik.values.education.findIndex(
+        (record) => record.id === overId
+      )
+
+      if (sourceIndex < 0 || destinationIndex < 0) return
 
       const reorderedEducation = reorder(
         formik.values.education,
-        result.source.index,
-        result.destination.index
+        sourceIndex,
+        destinationIndex
       )
 
       const withCorrectSortIndexes = reorderedEducation.map(
@@ -303,6 +326,12 @@ function JobseekerFormSectionEducation({
     [formik]
   )
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    })
+  )
+
   return (
     <>
       <Element
@@ -313,18 +342,15 @@ function JobseekerFormSectionEducation({
       >
         Add your relevant education.
       </Element>
-      <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable droppableId="id">
-          {(provided, snapshot) => (
-            <div {...provided.droppableProps} ref={provided.innerRef}>
-              {formik?.values?.education.map((item, index) => (
-                <Draggable key={item.id} draggableId={item.id} index={index}>
-                  {(provided, snapshot) => (
-                    <div
-                      ref={provided.innerRef}
-                      {...provided.draggableProps}
-                      {...provided.dragHandleProps}
-                    >
+      <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+        <SortableContext
+          items={formik.values.education.map((item) => item.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <div>
+            {formik?.values?.education.map((item, index) => (
+              <SortableItem key={item.id} id={item.id}>
+                <div>
                       <FormDraggableAccordion
                         title={
                           item.title ? item.title : 'Click me to add details'
@@ -418,15 +444,12 @@ function JobseekerFormSectionEducation({
                           </Columns>
                         ) : null}
                       </FormDraggableAccordion>
-                    </div>
-                  )}
-                </Draggable>
-              ))}
-              {provided.placeholder}
-            </div>
-          )}
-        </Droppable>
-      </DragDropContext>
+                </div>
+              </SortableItem>
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
 
       <div style={{ height: '30px' }} />
 
@@ -465,7 +488,7 @@ const formCertificationTypes = certificationTypes.map(({ id, label }) => ({
   label,
 }))
 
-function buildBlankEducationRecord(sortIndex: number = 1): FormEducationRecord {
+function buildBlankEducationRecord(sortIndex = 1): FormEducationRecord {
   return {
     id: `NEW-${uuidv4()}`,
     title: '',

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-cv-editables/AccordionFormCvLanguages.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-cv-editables/AccordionFormCvLanguages.tsx
@@ -224,6 +224,7 @@ export function JobseekerFormSectionLanguages({
           }
           onRemove={() => onRemove(item.id)}
           closeAccordionSignalSubject={closeAllAccordionsSignalSubject.current}
+          showDragHandle={false}
         >
           <FormSelect
             name={`workingLanguages[${index}].language`}

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-cv-editables/AccordionFormCvProfessionalExperience.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-cv-editables/AccordionFormCvProfessionalExperience.tsx
@@ -1,4 +1,15 @@
 import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import {
   TpJobseekerCvExperienceRecord,
   useFindAllTpJobseekerCvExperienceRecordsQuery,
   useTpJobseekerCvExperienceRecordCreateMutation,
@@ -20,7 +31,6 @@ import { reorder } from '@talent-connect/typescript-utilities'
 import { useFormik } from 'formik'
 import { cloneDeep } from 'lodash'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
-import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd'
 import { Columns, Element } from 'react-bulma-components'
 import { useQueryClient } from 'react-query'
 import { Subject } from 'rxjs'
@@ -28,6 +38,7 @@ import { v4 as uuidv4 } from 'uuid'
 import * as Yup from 'yup'
 import { useIsBusy } from '../../../hooks/useIsBusy'
 import { AccordionForm } from '../../molecules/AccordionForm'
+import { SortableItem } from '../../molecules/SortableItem'
 import {
   rolesAndResponsibilitiesAnswer,
   rolesAndResponsibilitiesPlaceholderText,
@@ -265,13 +276,25 @@ export function JobseekerFormSectionProfessionalExperience({
   }, [formik])
 
   const onDragEnd = useCallback(
-    (result: any) => {
-      if (!result.destination) return
+    ({ active, over }: DragEndEvent) => {
+      if (!over || active.id === over.id) return
+
+      const activeId = active.id.toString()
+      const overId = over.id.toString()
+
+      const sourceIndex = formik.values.experience.findIndex(
+        (record) => record.id === activeId
+      )
+      const destinationIndex = formik.values.experience.findIndex(
+        (record) => record.id === overId
+      )
+
+      if (sourceIndex < 0 || destinationIndex < 0) return
 
       const reorderedExperience = reorder(
         formik.values.experience,
-        result.source.index,
-        result.destination.index
+        sourceIndex,
+        destinationIndex
       )
 
       const withCorrectSortIndexes = reorderedExperience.map(
@@ -299,6 +322,12 @@ export function JobseekerFormSectionProfessionalExperience({
     [formik]
   )
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    })
+  )
+
   return (
     <>
       <Element
@@ -309,18 +338,15 @@ export function JobseekerFormSectionProfessionalExperience({
       >
         Add your relevant experience.
       </Element>
-      <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable droppableId="id">
-          {(provided) => (
-            <div {...provided.droppableProps} ref={provided.innerRef}>
-              {formik?.values?.experience.map((item, index) => (
-                <Draggable key={item.id} draggableId={item.id} index={index}>
-                  {(provided) => (
-                    <div
-                      ref={provided.innerRef}
-                      {...provided.draggableProps}
-                      {...provided.dragHandleProps}
-                    >
+      <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+        <SortableContext
+          items={formik.values.experience.map((item) => item.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <div>
+            {formik?.values?.experience.map((item, index) => (
+              <SortableItem key={item.id} id={item.id}>
+                <div>
                       <FormDraggableAccordion
                         title={
                           item.title ? item.title : 'Click me to add details'
@@ -412,15 +438,12 @@ export function JobseekerFormSectionProfessionalExperience({
                           </Columns>
                         ) : null}
                       </FormDraggableAccordion>
-                    </div>
-                  )}
-                </Draggable>
-              ))}
-              {provided.placeholder}
-            </div>
-          )}
-        </Droppable>
-      </DragDropContext>
+                </div>
+              </SortableItem>
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
 
       <div style={{ height: '30px' }} />
 
@@ -455,7 +478,7 @@ export function JobseekerFormSectionProfessionalExperience({
 }
 
 export function buildBlankExperienceRecord(
-  sortIndex: number = 1
+  sortIndex = 1
 ): FormExperienceRecord {
   return {
     id: `NEW-${uuidv4()}`,

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableEducation.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableEducation.tsx
@@ -1,4 +1,15 @@
 import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import {
   TpJobseekerProfileEducationRecord,
   useMyTpDataQuery,
   useTpJobseekerProfileEducationRecordCreateMutation,
@@ -25,7 +36,6 @@ import { useFormik } from 'formik'
 import { cloneDeep, isNumber } from 'lodash'
 import moment from 'moment'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd'
 import { Columns, Content, Element } from 'react-bulma-components'
 import ReactMarkdown from 'react-markdown'
 import { useQueryClient } from 'react-query'
@@ -36,6 +46,7 @@ import { useIsBusy } from '../../../hooks/useIsBusy'
 import { Editable } from '../../molecules/Editable'
 import { EmptySectionPlaceholder } from '../../molecules/EmptySectionPlaceholder'
 import { Location } from '../../molecules/Location'
+import { SortableItem } from '../../molecules/SortableItem'
 import { EditableEducationProfilePropFragment } from './EditableEducation.generated'
 
 interface Props {
@@ -339,13 +350,25 @@ function JobseekerFormSectionEducation({
   }, [formik])
 
   const onDragEnd = useCallback(
-    (result: any) => {
-      if (!result.destination) return
+    ({ active, over }: DragEndEvent) => {
+      if (!over || active.id === over.id) return
+
+      const activeId = active.id.toString()
+      const overId = over.id.toString()
+
+      const sourceIndex = formik.values.education.findIndex(
+        (record) => record.id === activeId
+      )
+      const destinationIndex = formik.values.education.findIndex(
+        (record) => record.id === overId
+      )
+
+      if (sourceIndex < 0 || destinationIndex < 0) return
 
       const reorderedEducation = reorder(
         formik.values.education,
-        result.source.index,
-        result.destination.index
+        sourceIndex,
+        destinationIndex
       )
 
       const withCorrectSortIndexes = reorderedEducation.map(
@@ -374,6 +397,12 @@ function JobseekerFormSectionEducation({
     [formik]
   )
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    })
+  )
+
   return (
     <>
       <Element
@@ -384,18 +413,15 @@ function JobseekerFormSectionEducation({
       >
         Add your relevant education.
       </Element>
-      <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable droppableId="id">
-          {(provided, snapshot) => (
-            <div {...provided.droppableProps} ref={provided.innerRef}>
-              {formik?.values?.education.map((item, index) => (
-                <Draggable key={item.id} draggableId={item.id} index={index}>
-                  {(provided, snapshot) => (
-                    <div
-                      ref={provided.innerRef}
-                      {...provided.draggableProps}
-                      {...provided.dragHandleProps}
-                    >
+      <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+        <SortableContext
+          items={formik.values.education.map((item) => item.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <div>
+            {formik?.values?.education.map((item, index) => (
+              <SortableItem key={item.id} id={item.id}>
+                <div>
                       <FormDraggableAccordion
                         title={
                           item.title ? item.title : 'Click me to add details'
@@ -489,14 +515,11 @@ function JobseekerFormSectionEducation({
                           </Columns>
                         ) : null}
                       </FormDraggableAccordion>
-                    </div>
-                  )}
-                </Draggable>
-              ))}
-              {provided.placeholder}
-            </div>
-          )}
-        </Droppable>
+                </div>
+              </SortableItem>
+            ))}
+          </div>
+        </SortableContext>
         <LightModal
           isOpen={Boolean(educationIdToRemove)}
           handleClose={() => setEducationIdToRemove(undefined)}
@@ -506,7 +529,7 @@ function JobseekerFormSectionEducation({
           ctaOnClick={() => onRemove(educationIdToRemove)}
           cancelLabel="Keep it"
         />
-      </DragDropContext>
+      </DndContext>
 
       <div style={{ height: '30px' }} />
 
@@ -545,7 +568,7 @@ const formCertificationTypes = certificationTypes.map(({ id, label }) => ({
   label,
 }))
 
-function buildBlankEducationRecord(sortIndex: number = 1): FormEducationRecord {
+function buildBlankEducationRecord(sortIndex = 1): FormEducationRecord {
   return {
     id: `NEW-${uuidv4()}`,
     title: '',

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableLanguages.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableLanguages.tsx
@@ -247,6 +247,7 @@ export function JobseekerFormSectionLanguages({
           }
           onRemove={() => onRemove(item.id)}
           closeAccordionSignalSubject={closeAllAccordionsSignalSubject.current}
+          showDragHandle={false}
         >
           <FormSelect
             name={`workingLanguages[${index}].language`}

--- a/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableProfessionalExperience.tsx
+++ b/apps/redi-talent-pool/src/components/organisms/jobseeker-profile-editables/EditableProfessionalExperience.tsx
@@ -1,4 +1,15 @@
 import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import {
   TpJobseekerProfileExperienceRecord,
   useMyTpDataQuery,
   useTpJobseekerProfileExperienceRecordCreateMutation,
@@ -23,7 +34,6 @@ import { useFormik } from 'formik'
 import { cloneDeep, isNumber } from 'lodash'
 import moment from 'moment'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd'
 import { Columns, Content, Element } from 'react-bulma-components'
 import ReactMarkdown from 'react-markdown'
 import { useQueryClient } from 'react-query'
@@ -34,6 +44,7 @@ import { useIsBusy } from '../../../hooks/useIsBusy'
 import { Editable } from '../../molecules/Editable'
 import { EmptySectionPlaceholder } from '../../molecules/EmptySectionPlaceholder'
 import { Location } from '../../molecules/Location'
+import { SortableItem } from '../../molecules/SortableItem'
 import { EditableProfessionalExperienceProfilePropFragment } from './EditableProfessionalExperience.generated'
 interface Props {
   profile?: EditableProfessionalExperienceProfilePropFragment
@@ -335,13 +346,25 @@ export function JobseekerFormSectionProfessionalExperience({
   }, [formik])
 
   const onDragEnd = useCallback(
-    (result: any) => {
-      if (!result.destination) return
+    ({ active, over }: DragEndEvent) => {
+      if (!over || active.id === over.id) return
+
+      const activeId = active.id.toString()
+      const overId = over.id.toString()
+
+      const sourceIndex = formik.values.experience.findIndex(
+        (record) => record.id === activeId
+      )
+      const destinationIndex = formik.values.experience.findIndex(
+        (record) => record.id === overId
+      )
+
+      if (sourceIndex < 0 || destinationIndex < 0) return
 
       const reorderedExperience = reorder(
         formik.values.experience,
-        result.source.index,
-        result.destination.index
+        sourceIndex,
+        destinationIndex
       )
 
       const withCorrectSortIndexes = reorderedExperience.map(
@@ -370,6 +393,12 @@ export function JobseekerFormSectionProfessionalExperience({
     [formik]
   )
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    })
+  )
+
   return (
     <>
       <Element
@@ -380,18 +409,15 @@ export function JobseekerFormSectionProfessionalExperience({
       >
         Add your relevant experience.
       </Element>
-      <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable droppableId="id">
-          {(provided) => (
-            <div {...provided.droppableProps} ref={provided.innerRef}>
-              {formik?.values?.experience.map((item, index) => (
-                <Draggable key={item.id} draggableId={item.id} index={index}>
-                  {(provided) => (
-                    <div
-                      ref={provided.innerRef}
-                      {...provided.draggableProps}
-                      {...provided.dragHandleProps}
-                    >
+      <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+        <SortableContext
+          items={formik.values.experience.map((item) => item.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <div>
+            {formik?.values?.experience.map((item, index) => (
+              <SortableItem key={item.id} id={item.id}>
+                <div>
                       <FormDraggableAccordion
                         title={
                           item.title ? item.title : 'Click me to add details'
@@ -484,14 +510,11 @@ export function JobseekerFormSectionProfessionalExperience({
                           </Columns>
                         ) : null}
                       </FormDraggableAccordion>
-                    </div>
-                  )}
-                </Draggable>
-              ))}
-              {provided.placeholder}
-            </div>
-          )}
-        </Droppable>
+                </div>
+              </SortableItem>
+            ))}
+          </div>
+        </SortableContext>
         <LightModal
           isOpen={Boolean(experienceIdToRemove)}
           handleClose={() => setExperienceIdToRemove(undefined)}
@@ -501,7 +524,7 @@ export function JobseekerFormSectionProfessionalExperience({
           ctaOnClick={() => onRemove(experienceIdToRemove)}
           cancelLabel="Keep it"
         />
-      </DragDropContext>
+      </DndContext>
 
       <div style={{ height: '30px' }} />
 
@@ -536,7 +559,7 @@ export function JobseekerFormSectionProfessionalExperience({
 }
 
 export function buildBlankExperienceRecord(
-  sortIndex: number = 1
+  sortIndex = 1
 ): FormExperienceRecord {
   return {
     id: `NEW-${uuidv4()}`,

--- a/libs/shared-atomic-design-components/src/lib/atoms/FormDraggableAccordion.tsx
+++ b/libs/shared-atomic-design-components/src/lib/atoms/FormDraggableAccordion.tsx
@@ -14,6 +14,7 @@ interface Props {
   onRemove?: () => void
   closeAccordionSignalSubject?: Subject<void>
   entryCategory?: string
+  showDragHandle?: boolean
 }
 
 function FormDraggableAccordion({
@@ -23,6 +24,7 @@ function FormDraggableAccordion({
   initialOpen = false,
   closeAccordionSignalSubject = null,
   entryCategory,
+  showDragHandle = true,
 }: Props) {
   const [showAnswer, setShowAnswer] = useState(initialOpen)
 
@@ -39,7 +41,10 @@ function FormDraggableAccordion({
       <Columns breakpoint="mobile" className="form-draggable-accordion__title">
         <Columns.Column onClick={() => setShowAnswer(!showAnswer)}>
           <Element style={{ display: 'flex' }}>
-            <AccordionHandleIcon style={{ marginRight: '.8rem' }} /> {title}
+            {showDragHandle ? (
+              <AccordionHandleIcon style={{ marginRight: '.8rem' }} />
+            ) : null}{' '}
+            {title}
           </Element>
         </Columns.Column>
         <Columns.Column onClick={() => setShowAnswer(!showAnswer)} narrow>

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
   },
   "private": true,
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@formbricks/js": "^2.1.0",
@@ -112,7 +115,6 @@
     "passport-jwt": "^4.0.0",
     "query-string": "^7.0.0",
     "react": "17.0.2",
-    "react-beautiful-dnd": "^13.1.1",
     "react-bulma-components": "^3.2.0",
     "react-datepicker": "^3.8.0",
     "react-dom": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,7 +1414,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.16.4", "@babel/runtime@^7.17.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.14.8", "@babel/runtime@^7.16.3", "@babel/runtime@^7.16.4", "@babel/runtime@^7.17.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.17.9"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
@@ -1566,6 +1566,37 @@
   version "0.5.7"
   resolved "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
+
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz#1f9382b90d835cd5c65d92824fa9dafb78c4c3e8"
+  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
 
 "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"
@@ -5514,16 +5545,6 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
-"@types/react-redux@^7.1.20":
-  version "7.1.23"
-  resolved "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.23.tgz"
-  integrity sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==
-  dependencies:
-    "@types/hoist-non-react-statics" "^3.3.0"
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-    redux "^4.0.0"
-
 "@types/react-router-dom@5.3.3":
   version "5.3.3"
   resolved "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz"
@@ -8926,13 +8947,6 @@ csprng@*:
   integrity sha1-S8aPEvo2jSUqWYQcusqXSxirReI=
   dependencies:
     sequin "*"
-
-css-box-model@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz"
-  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
-  dependencies:
-    tiny-invariant "^1.0.6"
 
 css-declaration-sorter@^6.2.2:
   version "6.2.2"
@@ -15324,11 +15338,6 @@ memfs@^3.1.2, memfs@^3.4.1:
   dependencies:
     fs-monkey "1.0.3"
 
-memoize-one@^5.1.1:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
-
 memoize-one@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
@@ -18143,11 +18152,6 @@ quill@^1.3.7:
     parchment "^1.1.4"
     quill-delta "^3.6.2"
 
-raf-schd@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz"
-  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
-
 ramda@^0.21.0:
   version "0.21.0"
   resolved "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz"
@@ -18220,19 +18224,6 @@ rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-beautiful-dnd@^13.1.1:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz#b0f3087a5840920abf8bb2325f1ffa46d8c4d0a2"
-  integrity sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-    css-box-model "^1.2.0"
-    memoize-one "^5.1.1"
-    raf-schd "^4.0.2"
-    react-redux "^7.2.0"
-    redux "^4.0.4"
-    use-memo-one "^1.1.1"
 
 react-bulma-components@^3.2.0:
   version "3.4.0"
@@ -18481,18 +18472,6 @@ react-reconciler@^0.23.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.17.0"
-
-react-redux@^7.2.0:
-  version "7.2.8"
-  resolved "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz"
-  integrity sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@types/react-redux" "^7.1.20"
-    hoist-non-react-statics "^3.3.2"
-    loose-envify "^1.4.0"
-    prop-types "^15.7.2"
-    react-is "^17.0.2"
 
 react-refresh@^0.10.0:
   version "0.10.0"
@@ -18760,7 +18739,7 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-redux@^4.0.0, redux@^4.0.4:
+redux@^4.0.0:
   version "4.1.2"
   resolved "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz"
   integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
@@ -20971,7 +20950,7 @@ tiny-inflate@^1.0.0, tiny-inflate@^1.0.2:
   resolved "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz"
   integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
-tiny-invariant@^1.0.0, tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
+tiny-invariant@^1.0.0, tiny-invariant@^1.0.2:
   version "1.2.0"
   resolved "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz"
   integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
@@ -21720,11 +21699,6 @@ use-latest@^1.0.0:
   integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
-
-use-memo-one@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz"
-  integrity sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
 
 use-query-params@^1.2.2:
   version "1.2.3"


### PR DESCRIPTION
Closes #1032 

## Summary
Migrates Talent Pool sortable education and professional experience forms from deprecated react-beautiful-dnd to dnd-kit, and removes misleading drag handles from non-sortable language accordions.

## Changes

* Replaced react-beautiful-dnd with @dnd-kit/core, @dnd-kit/sortable, and @dnd-kit/utilities.
* Migrated 4 sortable form sections to DndContext and SortableContext.
* Added shared SortableItem molecule to avoid duplicated useSortable wrapper code.
* Preserved existing reorder behavior and sortIndex persistence.
* Added showDragHandle to FormDraggableAccordion, defaulting to true.
* Disabled drag handles for language accordions, since language items are not sortable.

## Screenshots & GIFs
**Languages without Reorder Icon:**

<img width="1352" height="1376" alt="CleanShot 2026-06-22 at 20 47 35@2x" src="https://github.com/user-attachments/assets/916a9a4d-4ea7-4c91-b6de-053398b0c2cd" />

**Jobseeker Profile - Professional Experience**
<img width="800" height="636" alt="CleanShot 2026-06-22 at 20 49 50" src="https://github.com/user-attachments/assets/84dd3750-2baa-48c0-bd8e-18e28954c0f0" />

**Jobseeker Profile - Education:**
<img width="800" height="723" alt="CleanShot 2026-06-22 at 20 51 22" src="https://github.com/user-attachments/assets/cacf0937-c375-4e27-a0c0-d83e069d7a18" />

**CV Builder - Experience:**
<img width="800" height="425" alt="CleanShot 2026-06-22 at 20 53 47" src="https://github.com/user-attachments/assets/8c9dc342-4fc4-4fad-a199-00bcdffcda22" />

**CV Builder - Education**
<img width="800" height="502" alt="CleanShot 2026-06-22 at 20 54 39" src="https://github.com/user-attachments/assets/7fe030a0-147e-4f39-ae8e-bdc57c0fc1a3" />



